### PR TITLE
YakiHonne hyperlinks logic for events

### DIFF
--- a/src/components/ContentForm.vue
+++ b/src/components/ContentForm.vue
@@ -13,7 +13,7 @@ import {
   IconLock,
   IconUser,
   IconBolt,
-  IconShare
+  IconShare,
   IconExternalLink,
   IconChevronDown
 } from '@iconify-prerendered/vue-tabler'

--- a/src/components/ContentForm.vue
+++ b/src/components/ContentForm.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, computed, watch } from 'vue'
+import * as nip19 from 'nostr-tools/nip19'
 import { 
   IconFileText, 
   IconMail, 
@@ -13,6 +14,8 @@ import {
   IconUser,
   IconBolt,
   IconShare
+  IconExternalLink,
+  IconChevronDown
 } from '@iconify-prerendered/vue-tabler'
 
 const props = defineProps({
@@ -52,6 +55,8 @@ const monetizationModels = [
 ]
 
 const newTag = ref('')
+const showClientDropdown = ref(false)
+const dropdownRef = ref(null)
 
 // Watch for monetization model changes to automatically set price to 0 for free content
 watch(() => props.form.monetizationModel, (newModel) => {
@@ -80,6 +85,47 @@ const addTag = () => {
 
 const removeTag = (index) => {
   props.form.tags.splice(index, 1)
+}
+
+// Close dropdown when clicking outside
+const handleClickOutside = (event) => {
+  if (dropdownRef.value && !dropdownRef.value.contains(event.target)) {
+    showClientDropdown.value = false
+  }
+}
+
+// Toggle client dropdown
+const toggleClientDropdown = () => {
+  showClientDropdown.value = !showClientDropdown.value
+}
+
+// Get URL for different Nostr clients for long-form content
+const getNostrClientUrl = (client, content) => {
+  if (!content || !content.nostrEventId) return '#'
+  
+  try {
+    switch (client) {
+      case 'yakihonne':
+        // For long-form content, use naddrEncode if we have the necessary data
+        if (content.creatorPubkey && content.tags && content.tags.length > 0) {
+          // Try to create naddr format for long-form content
+          return `https://yakihonne.com/article/${nip19.naddrEncode({
+            pubkey: content.creatorPubkey,
+            kind: 30023,
+            identifier: content.id
+          })}`
+        }
+        // Fallback to nevent format
+        return `https://yakihonne.com/${nip19.neventEncode({ id: content.nostrEventId })}`
+      case 'primal':
+        return `https://primal.net/e/${content.nostrEventId}`
+      default:
+        return `https://primal.net/e/${content.nostrEventId}`
+    }
+  } catch (error) {
+    console.error('Failed to generate client URL:', error)
+    return '#'
+  }
 }
 
 const handleSubmit = () => {

--- a/src/components/ZapEventModal.vue
+++ b/src/components/ZapEventModal.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, onMounted, watch, onUnmounted, computed, inject } from 'vue'
+import * as nip19 from 'nostr-tools/nip19'
 import {
   IconX, 
   IconBolt, 
@@ -105,7 +106,7 @@ const getNostrClientUrl = (client) => {
       case 'primal':
         return `https://primal.net/e/${event.value.id}`
       case 'yakihonne':
-        return `https://yakihonne.com/e/${event.value.id}`
+        return `https://yakihonne.com/${nip19.neventEncode({ id: event.value.id })}`
       default:
         return `https://primal.net/e/${event.value.id}`
     }

--- a/src/components/ZapEventModal.vue
+++ b/src/components/ZapEventModal.vue
@@ -24,7 +24,6 @@ import {
 import { nostrRelayManager } from '../utils/nostrRelayManager.js'
 import { useNostrAuth } from '../composables/useNostrAuth.js' 
 import { useContentZaps } from '../composables/useContentZaps.js'
-import * as nip19 from 'nostr-tools/nip19'
 
 const props = defineProps({
   eventId: {

--- a/src/composables/useNostrLongForm.js
+++ b/src/composables/useNostrLongForm.js
@@ -6,6 +6,14 @@ import { finalizeEvent, verifyEvent } from 'nostr-tools/pure'
 import { contentService } from '../utils/contentService.js'
 
 // Global state for long-form content
+// Helper function to extract d tag identifier from event
+const getDTagIdentifier = (event) => {
+  // Look for d tag in the event tags
+  const dTag = event.tags.find(tag => tag[0] === 'd')
+  // Return the d tag value if found, otherwise fall back to event id
+  return dTag && dTag[1] ? dTag[1] : event.id
+}
+
 const longFormContent = ref([])
 const isLoading = ref(false)
 const error = ref('')
@@ -250,7 +258,7 @@ export function useNostrLongForm() {
     
     // Create content object
     return {
-      id: event.id,
+      id: getDTagIdentifier(event), // Use d tag as primary identifier
       nostrEventId: event.id,
       title,
       description,

--- a/src/pages/Analytics.vue
+++ b/src/pages/Analytics.vue
@@ -2,6 +2,7 @@
 import { computed, inject, ref, onMounted } from 'vue'
 import { IconClock, IconBook, IconChartLine, IconRefresh, IconUsers, IconTrendingUp, IconAlertCircle, IconBolt } from '@iconify-prerendered/vue-tabler'
 import { filterZapsByTimeRange } from '../utils/timeFilter.js'
+import * as nip19 from 'nostr-tools/nip19'
 import UserProfileModal from '../components/UserProfileModal.vue'
 import { generateFallbackAvatar } from '../composables/useContentZaps.js'
 import { IconExternalLink } from '@iconify-prerendered/vue-tabler'
@@ -674,7 +675,7 @@ const summaryStats = computed(() => {
                   <p class="font-medium text-gray-900 truncate">{{ topSupporters[0].profile?.name || topSupporters[0].pubkey.substring(0, 8) + '...' }}</p>
                   <a 
                     v-if="topSupporters[0].pubkey"
-                    :href="`https://yakihonne.com/users/${topSupporters[0].pubkey}`" 
+                    :href="`https://yakihonne.com/${nip19.npubEncode(topSupporters[0].pubkey)}`" 
                     target="_blank" 
                     rel="noopener noreferrer"
                     class="ml-2 p-1 text-purple-600 hover:text-purple-800 hover:bg-purple-50 rounded-full transition-colors"

--- a/src/pages/Content.vue
+++ b/src/pages/Content.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref, onUnmounted } from 'vue'
+import * as nip19 from 'nostr-tools/nip19'
 import { 
   IconFileText, 
   IconPlus, 
@@ -12,7 +13,9 @@ import {
   IconShare,
   IconLoader,
   IconCheck,
-  IconAlertCircle
+  IconAlertCircle,
+  IconExternalLink,
+  IconChevronDown
 } from '@iconify-prerendered/vue-tabler'
 import { useContent } from '../composables/useContent.js'
 import { useContentZaps } from '../composables/useContentZaps.js'
@@ -25,6 +28,10 @@ import ContentForm from '../components/ContentForm.vue'
 import ContentPerformance from '../components/ContentPerformance.vue'
 
 const { isAuthenticated, currentUser, userProfile, login } = useNostrAuth()
+
+// UI state for dropdown
+const showClientDropdown = ref(false)
+const dropdownRef = ref(null)
 
 // Use the long-form content composable
 const { fetchUserLongFormContent } = useNostrLongForm()
@@ -197,6 +204,56 @@ const formatZapTime = (timestamp) => {
   if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`
   return `${Math.floor(diff / 86400000)}d ago`
 }
+
+// Close dropdown when clicking outside
+const handleClickOutside = (event) => {
+  if (dropdownRef.value && !dropdownRef.value.contains(event.target)) {
+    showClientDropdown.value = false
+  }
+}
+
+// Toggle client dropdown
+const toggleClientDropdown = () => {
+  showClientDropdown.value = !showClientDropdown.value
+}
+
+// Get URL for different Nostr clients for long-form content
+const getNostrClientUrl = (client, content) => {
+  if (!content || !content.nostrEventId) return '#'
+  
+  try {
+    switch (client) {
+      case 'yakihonne':
+        // For long-form content, use naddrEncode if we have the necessary data
+        if (content.creatorPubkey && content.tags && content.tags.length > 0) {
+          // Try to create naddr format for long-form content
+          return `https://yakihonne.com/article/${nip19.naddrEncode({
+            pubkey: content.creatorPubkey,
+            kind: 30023,
+            identifier: content.id
+          })}`
+        }
+        // Fallback to nevent format
+        return `https://yakihonne.com/${nip19.neventEncode({ id: content.nostrEventId })}`
+      case 'primal':
+        return `https://primal.net/e/${content.nostrEventId}`
+      default:
+        return `https://primal.net/e/${content.nostrEventId}`
+    }
+  } catch (error) {
+    console.error('Failed to generate client URL:', error)
+    return '#'
+  }
+}
+
+// Add/remove event listener for dropdown
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', handleClickOutside)
+})
 </script>
 
 <template>
@@ -380,7 +437,39 @@ const formatZapTime = (timestamp) => {
           <div class="p-6">
             <!-- Content Header -->
             <div class="mb-6">
-              <h1 class="text-3xl font-bold text-gray-900 mb-4">{{ selectedContent.title }}</h1>
+              <div class="flex items-center justify-between mb-4">
+                <h1 class="text-3xl font-bold text-gray-900">{{ selectedContent.title }}</h1>
+                
+                <!-- Open in Client Dropdown -->
+                <div v-if="selectedContent.nostrEventId" class="relative" ref="dropdownRef">
+                  <button
+                    @click="toggleClientDropdown"
+                    class="text-sm text-purple-600 hover:text-purple-700 font-medium flex items-center space-x-1 bg-purple-50 px-3 py-1 rounded-lg hover:bg-purple-100 transition-colors"
+                  >
+                    <IconExternalLink class="w-4 h-4" />
+                    <span>Open in client</span>
+                    <IconChevronDown :class="['w-3 h-3 transition-transform', showClientDropdown ? 'rotate-180' : '']" />
+                  </button>
+                  
+                  <!-- Client Dropdown -->
+                  <div 
+                    v-if="showClientDropdown"
+                    class="absolute right-0 mt-1 w-40 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-10"
+                  >
+                    <a :href="getNostrClientUrl('primal', selectedContent)" target="_blank" rel="noopener noreferrer" 
+                       class="block px-4 py-2 text-sm text-gray-700 hover:bg-purple-50 hover:text-purple-700 flex items-center gap-2">
+                      <span class="w-4 h-4 flex items-center justify-center text-orange-600">🌐</span>
+                      <span>Primal.net</span>
+                    </a>
+                    <a :href="getNostrClientUrl('yakihonne', selectedContent)" target="_blank" rel="noopener noreferrer"
+                       class="block px-4 py-2 text-sm text-gray-700 hover:bg-purple-50 hover:text-purple-700 flex items-center gap-2">
+                      <span class="w-4 h-4 flex items-center justify-center text-purple-600">🍜</span>
+                      <span>Yakihonne</span>
+                    </a>
+                  </div>
+                </div>
+              </div>
+              
               <p class="text-lg text-gray-600 mb-4">{{ selectedContent.description }}</p>
 
               <!-- Content Meta -->

--- a/src/pages/Content.vue
+++ b/src/pages/Content.vue
@@ -224,9 +224,9 @@ const getNostrClientUrl = (client, content) => {
   try {
     switch (client) {
       case 'yakihonne':
-        // For long-form content, use naddrEncode if we have the necessary data
-        if (content.creatorPubkey && content.tags && content.tags.length > 0) {
-          // Try to create naddr format for long-form content
+        // For long-form content (kind 30023), use naddrEncode if we have the necessary data
+        if (content.creatorPubkey && content.id && content.nostrEventId) {
+          // Create naddr format for long-form content
           return `https://yakihonne.com/article/${nip19.naddrEncode({
             pubkey: content.creatorPubkey,
             kind: 30023,

--- a/src/pages/ContentUnlock.vue
+++ b/src/pages/ContentUnlock.vue
@@ -24,8 +24,40 @@
       <!-- Article Preview -->
       <div v-else-if="articleEvent && !isUnlocked" class="space-y-6">
         <!-- Article Header -->
-        <div class="text-center">
-          <h1 class="text-3xl font-bold text-gray-900 mb-4">{{ articleTitle }}</h1>
+        <div class="text-center relative">
+          <div class="flex items-center justify-center mb-4">
+            <h1 class="text-3xl font-bold text-gray-900">{{ articleTitle }}</h1>
+            
+            <!-- Open in Client Dropdown -->
+            <div v-if="articleEvent" class="relative ml-3" ref="dropdownRef">
+              <button
+                @click="toggleClientDropdown"
+                class="text-sm text-purple-600 hover:text-purple-700 font-medium flex items-center space-x-1 bg-purple-50 px-3 py-1 rounded-lg hover:bg-purple-100 transition-colors"
+              >
+                <IconExternalLink class="w-4 h-4" />
+                <span>Open in client</span>
+                <IconChevronDown :class="['w-3 h-3 transition-transform', showClientDropdown ? 'rotate-180' : '']" />
+              </button>
+              
+              <!-- Client Dropdown -->
+              <div 
+                v-if="showClientDropdown"
+                class="absolute right-0 mt-1 w-40 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-10"
+              >
+                <a :href="getNostrClientUrl('primal', articleEvent.id)" target="_blank" rel="noopener noreferrer" 
+                   class="block px-4 py-2 text-sm text-gray-700 hover:bg-purple-50 hover:text-purple-700 flex items-center gap-2">
+                  <span class="w-4 h-4 flex items-center justify-center text-orange-600">🌐</span>
+                  <span>Primal.net</span>
+                </a>
+                <a :href="getNostrClientUrl('yakihonne', articleEvent.id)" target="_blank" rel="noopener noreferrer"
+                   class="block px-4 py-2 text-sm text-gray-700 hover:bg-purple-50 hover:text-purple-700 flex items-center gap-2">
+                  <span class="w-4 h-4 flex items-center justify-center text-purple-600">🍜</span>
+                  <span>Yakihonne</span>
+                </a>
+              </div>
+            </div>
+          </div>
+          
           <p class="text-lg text-gray-600 mb-6">{{ articlePreview }}</p>
           
           <!-- Article Meta -->
@@ -134,13 +166,16 @@
 
 <script setup>
 import { ref, onMounted, computed, inject, watch } from 'vue'
+import * as nip19 from 'nostr-tools/nip19'
 import { 
   IconArrowLeft, 
   IconBolt, 
   IconLoader, 
   IconCheck, 
   IconAlertCircle,
-  IconShare
+  IconShare,
+  IconExternalLink,
+  IconChevronDown
 } from '@iconify-prerendered/vue-tabler'
 import { SimplePool } from 'nostr-tools/pool'
 import { nwcPaymentHandler } from '../utils/nwcPayment.js'
@@ -162,6 +197,8 @@ const isProcessingPayment = ref(false)
 const paymentStatus = ref('')
 const paymentInvoice = ref('')
 const nwcUrl = ref('')
+const showClientDropdown = ref(false)
+const dropdownRef = ref(null)
 
 // Computed properties
 const articleTitle = computed(() => {
@@ -319,6 +356,47 @@ const initiatePayment = async () => {
 const goBack = () => {
   currentPage.value = 'content'
   // Update URL
+
+// Toggle client dropdown
+const toggleClientDropdown = () => {
+  showClientDropdown.value = !showClientDropdown.value
+}
+
+// Close dropdown when clicking outside
+const handleClickOutside = (event) => {
+  if (dropdownRef.value && !dropdownRef.value.contains(event.target)) {
+    showClientDropdown.value = false
+  }
+}
+
+// Get URL for different Nostr clients for long-form content
+const getNostrClientUrl = (client, eventId) => {
+  if (!eventId) return '#'
+  
+  try {
+    switch (client) {
+      case 'yakihonne':
+        // For long-form content, use neventEncode
+        return `https://yakihonne.com/${nip19.neventEncode({ id: eventId })}`
+      case 'primal':
+        return `https://primal.net/e/${eventId}`
+      default:
+        return `https://primal.net/e/${eventId}`
+    }
+  } catch (error) {
+    console.error('Failed to generate client URL:', error)
+    return '#'
+  }
+}
+
+// Add/remove event listener for dropdown
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', handleClickOutside)
+})
   const url = new URL(window.location)
   url.searchParams.delete('page')
   url.searchParams.delete('eventId')

--- a/src/pages/ContentUnlock.vue
+++ b/src/pages/ContentUnlock.vue
@@ -376,8 +376,20 @@ const getNostrClientUrl = (client, eventId) => {
   try {
     switch (client) {
       case 'yakihonne':
-        // For long-form content, use neventEncode
-        return `https://yakihonne.com/${nip19.neventEncode({ id: eventId })}`
+        // For long-form content (kind 30023), use naddrEncode if we have the necessary data
+        if (event.value.kind === 30023 && event.value.pubkey) {
+          // Get the d tag identifier (or fallback to event id)
+          const dTag = event.value.tags.find(tag => tag[0] === 'd')?.[1] || event.value.id
+          
+          // Create naddr format for long-form content
+          return `https://yakihonne.com/article/${nip19.naddrEncode({
+            pubkey: event.value.pubkey,
+            kind: 30023,
+            identifier: dTag
+          })}`
+        }
+        // Fallback to nevent format
+        return `https://yakihonne.com/${nip19.neventEncode({ id: event.value.id })}`
       case 'primal':
         return `https://primal.net/e/${eventId}`
       default:

--- a/src/pages/ContentUnlock.vue
+++ b/src/pages/ContentUnlock.vue
@@ -377,23 +377,23 @@ const getNostrClientUrl = (client, eventId) => {
     switch (client) {
       case 'yakihonne':
         // For long-form content (kind 30023), use naddrEncode if we have the necessary data
-        if (event.value.kind === 30023 && event.value.pubkey) {
+        if (articleEvent && articleEvent.kind === 30023 && articleEvent.pubkey) {
           // Get the d tag identifier (or fallback to event id)
-          const dTag = event.value.tags.find(tag => tag[0] === 'd')?.[1] || event.value.id
+          const dTag = articleEvent.tags.find(tag => tag[0] === 'd')?.[1] || articleEvent.id
           
           // Create naddr format for long-form content
           return `https://yakihonne.com/article/${nip19.naddrEncode({
-            pubkey: event.value.pubkey,
+            pubkey: articleEvent.pubkey,
             kind: 30023,
             identifier: dTag
           })}`
         }
         // Fallback to nevent format
-        return `https://yakihonne.com/${nip19.neventEncode({ id: event.value.id })}`
+        return `https://yakihonne.com/${nip19.neventEncode({ id: articleEvent })}`
       case 'primal':
-        return `https://primal.net/e/${eventId}`
+        return `https://primal.net/e/${articleEvent}`
       default:
-        return `https://primal.net/e/${eventId}`
+        return `https://primal.net/e/${articleEvent}`
     }
   } catch (error) {
     console.error('Failed to generate client URL:', error)
@@ -438,4 +438,4 @@ watch(isContentLoading, (loading) => {
 .btn-secondary {
   @apply bg-gray-600 hover:bg-gray-700 text-white px-6 py-3 rounded-lg font-medium transition-colors flex items-center justify-center space-x-2;
 }
-</style> 
+</style>

--- a/src/pages/Notes.vue
+++ b/src/pages/Notes.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted, computed, onUnmounted, watch } from 'vue'
 import EmojiPicker from 'vue3-emoji-picker'
 import 'vue3-emoji-picker/css'
+import * as nip19 from 'nostr-tools/nip19'
 import {
   IconFileText, 
   IconPlus, 
@@ -195,7 +196,7 @@ const getNostrClientUrl = (client, noteId) => {
       case 'primal':
         return `https://primal.net/e/${noteId}`
       case 'yakihonne':
-        return `https://yakihonne.com/e/${noteId}`
+        return `https://yakihonne.com/${nip19.neventEncode({ id: noteId })}`
       case 'highlighter':
         return `https://highlighter.com/a/note1${nip19.noteEncode(noteId)}`
       default:


### PR DESCRIPTION
Added correct Linking to YakiHonne client for events in ZapTracker like "Notes", "Long-Form Content" and "Profiles"

Implemented based on this information with NostrTools using Nip-19.

```
For notes we have the following format
- <rootDomain>/notes/<neventEncode>
- <rootDomain>/notes/<noteEncode>

For long form notes
- <rootDomain>/article/<naddrEncode>
- <rootDomain>/articles/<userNip05>/<articleDTagIdentifier>

Now for universal URL parsing, and probably the easiest is
<rootDomain>/<anyTypeOfEncoding>
```