### PR TITLE
✨ Feature: Comprehensive Engagement Metrics Display (Likes, Reposts, Bookmarks) for Notes & Content

### DIFF
--- a/src/components/ContentList.vue
+++ b/src/components/ContentList.vue
@@ -226,9 +226,9 @@ const getSalesTooltip = (item) => {
 
                 <EngagementMetrics 
                   v-if="item.nostrEventId"
-                  :key="`content-engagement-${item.id}-${getEngagementCounts(item.nostrEventId).totalEngagement}-${item.zapAmount || 0}`"
+                  :key="`content-engagement-${item.id}-${getEngagementCounts(item.nostrEventId).totalEngagement}-${item.zapCount || 0}`"
                   :engagement-counts="getEngagementCounts(item.nostrEventId)"
-                  :zap-count="item.zapAmount || 0"
+                  :zap-count="item.zapCount || 0"
                   size="default"
                   text-size="text-xs"
                   :show-all-metrics="false"

--- a/src/components/ContentList.vue
+++ b/src/components/ContentList.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref, onMounted, onUnmounted } from 'vue'
+import { ref, onMounted, onUnmounted, watch } from 'vue'
 import { 
   IconFileText, 
   IconMail, 
@@ -17,6 +17,8 @@ import {
   IconUsers,
   IconMenu
 } from '@iconify-prerendered/vue-tabler'
+import EngagementMetrics from './EngagementMetrics.vue'
+import { useEngagementMetrics } from '../composables/useEngagementMetrics.js'
 
 const props = defineProps({
   items: {
@@ -24,6 +26,12 @@ const props = defineProps({
     required: true
   }
 })
+
+const { 
+  getEngagementCounts, 
+  startEngagementTracking,
+  startLongFormContentTracking
+} = useEngagementMetrics()
 
 // Track which dropdown is currently open
 const openDropdownId = ref(null)
@@ -38,11 +46,33 @@ const handleClickOutside = (event) => {
 // Add/remove event listener
 onMounted(() => {
   document.addEventListener('click', handleClickOutside)
+  
+      props.items.forEach(item => {
+      if (item.nostrEventId) {
+        if (item.creatorPubkey && item.id) {
+          startLongFormContentTracking(item.nostrEventId, item.creatorPubkey, item.id)
+        } else {
+          startEngagementTracking(item.nostrEventId)
+        }
+      }
+    })
 })
 
 onUnmounted(() => {
   document.removeEventListener('click', handleClickOutside)
 })
+
+watch(() => props.items, (newItems) => {
+  newItems.forEach(item => {
+    if (item.nostrEventId) {
+      if (item.creatorPubkey && item.id) {
+        startLongFormContentTracking(item.nostrEventId, item.creatorPubkey, item.id)
+      } else {
+        startEngagementTracking(item.nostrEventId)
+      }
+    }
+  })
+}, { deep: true })
 
 const emit = defineEmits(['edit', 'delete', 'preview', 'duplicate', 'share', 'publish-nostr'])
 
@@ -193,6 +223,18 @@ const getSalesTooltip = (item) => {
                 <span v-if="item.nostrEventId && item.zapCount === 0" class="text-orange-500">
                   ⚡ Ready for zaps
                 </span>
+
+                <EngagementMetrics 
+                  v-if="item.nostrEventId"
+                  :key="`content-engagement-${item.id}-${getEngagementCounts(item.nostrEventId).totalEngagement}-${item.zapAmount || 0}`"
+                  :engagement-counts="getEngagementCounts(item.nostrEventId)"
+                  :zap-count="item.zapAmount || 0"
+                  size="default"
+                  text-size="text-xs"
+                  :show-all-metrics="false"
+                  :show-no-engagement-text="true"
+                  :show-tooltips="true"
+                />
               </div>
             </div>
           </div>
@@ -394,6 +436,7 @@ const getSalesTooltip = (item) => {
 .line-clamp-2 {
   display: -webkit-box;
   -webkit-line-clamp: 2;
+  line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }

--- a/src/components/EngagementMetrics.vue
+++ b/src/components/EngagementMetrics.vue
@@ -1,0 +1,153 @@
+<script setup>
+import { computed } from 'vue'
+import {
+  IconHeartFilled,
+  IconHeart,
+  IconRepeat,
+  IconBolt,
+  IconBookmarkFilled,
+  IconBookmark
+} from '@iconify-prerendered/vue-tabler'
+
+const props = defineProps({
+  engagementCounts: {
+    type: Object,
+    required: true,
+    default: () => ({
+      likes: 0,
+      reposts: 0,
+      bookmarks: 0,
+      totalEngagement: 0
+    })
+  },
+  zapCount: {
+    type: Number,
+    default: 0
+  },
+  size: {
+    type: String,
+    default: 'default', 
+    validator: (value) => ['default', 'small', 'medium', 'large'].includes(value)
+  },
+  showAllMetrics: {
+    type: Boolean,
+    default: false
+  },
+  textSize: {
+    type: String,
+    default: 'text-xs'
+  },
+  showNoEngagementText: {
+    type: Boolean,
+    default: true
+  },
+  showTooltips: {
+    type: Boolean,
+    default: true
+  }
+})
+
+const iconSizeClass = computed(() => ({
+  small: 'w-3 h-3',
+  medium: 'w-3.3 h-3.2',
+  default: 'w-4 h-4', 
+  large: 'w-5 h-5'
+}[props.size]))
+
+const hasEngagement = computed(() => 
+  (props.engagementCounts?.totalEngagement || 0) > 0 || props.zapCount > 0
+)
+
+const safeEngagementCounts = computed(() => ({
+  likes: props.engagementCounts?.likes || 0,
+  reposts: props.engagementCounts?.reposts || 0,
+  bookmarks: props.engagementCounts?.bookmarks || 0,
+  totalEngagement: props.engagementCounts?.totalEngagement || 0
+}))
+</script>
+
+<template>
+  <template v-if="hasEngagement || showAllMetrics">
+    <span v-if="safeEngagementCounts.likes > 0 || showAllMetrics" :class="['flex items-center gap-1', showTooltips ? 'tooltip-container' : '']">
+      <IconHeartFilled v-if="safeEngagementCounts.likes > 0" :class="[iconSizeClass, 'text-red-500']" />
+      <IconHeart v-else :class="[iconSizeClass, 'text-gray-400']" />
+      <span :class="textSize">{{ safeEngagementCounts.likes }}</span>
+      <div v-if="showTooltips" class="custom-tooltip">{{ safeEngagementCounts.likes }} likes</div>
+    </span>
+    
+    <span v-if="safeEngagementCounts.reposts > 0 || showAllMetrics" :class="['flex items-center gap-1', showTooltips ? 'tooltip-container' : '']">
+      <IconRepeat :class="[iconSizeClass, safeEngagementCounts.reposts > 0 ? 'text-green-500 font-bold' : 'text-gray-400']" />
+      <span :class="textSize">{{ safeEngagementCounts.reposts }}</span>
+      <div v-if="showTooltips" class="custom-tooltip">{{ safeEngagementCounts.reposts }} reposts</div>
+    </span>
+    
+    <span v-if="zapCount > 0 || showAllMetrics" :class="['flex items-center gap-1', showTooltips ? 'tooltip-container' : '']">
+      <IconBolt :class="[iconSizeClass, zapCount > 0 ? 'text-orange-500 font-bold' : 'text-gray-400']" />
+      <span :class="textSize">{{ zapCount }}</span>
+      <div v-if="showTooltips" class="custom-tooltip">{{ zapCount }} zaps</div>
+    </span>
+    
+    <span v-if="safeEngagementCounts.bookmarks > 0 || showAllMetrics" :class="['flex items-center gap-1', showTooltips ? 'tooltip-container' : '']">
+      <IconBookmarkFilled v-if="safeEngagementCounts.bookmarks > 0" :class="[iconSizeClass, 'text-blue-500']" />
+      <IconBookmark v-else :class="[iconSizeClass, 'text-gray-400']" />
+      <span :class="textSize">{{ safeEngagementCounts.bookmarks }}</span>
+      <div v-if="showTooltips" class="custom-tooltip">{{ safeEngagementCounts.bookmarks }} bookmarks</div>
+    </span>
+  </template>
+  
+  <span v-else-if="showNoEngagementText" class="text-gray-400" :class="textSize">
+    No Engagement Yet
+  </span>
+</template>
+
+<style scoped>
+
+.tooltip-container {
+  position: relative;
+  cursor: pointer;
+}
+
+.custom-tooltip {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: rgba(0, 0, 0, 0.9);
+  color: white;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+  z-index: 50;
+  pointer-events: none;
+  
+  opacity: 0;
+  visibility: hidden;
+  transform: translateX(-50%) translateY(-4px);
+  transition: all 0.2s ease-in-out;
+}
+
+.custom-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 4px solid transparent;
+  border-top-color: rgba(0, 0, 0, 0.9);
+}
+
+.tooltip-container:hover .custom-tooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(-8px);
+}
+
+@media (max-width: 640px) {
+  .custom-tooltip {
+    font-size: 11px;
+    padding: 4px 8px;
+  }
+}
+</style>

--- a/src/components/EngagementMetrics.vue
+++ b/src/components/EngagementMetrics.vue
@@ -58,6 +58,13 @@ const hasEngagement = computed(() =>
   (props.engagementCounts?.totalEngagement || 0) > 0 || props.zapCount > 0
 )
 
+const hasAnyEngagement = computed(() => 
+  (props.engagementCounts?.likes || 0) > 0 || 
+  (props.engagementCounts?.reposts || 0) > 0 || 
+  (props.engagementCounts?.bookmarks || 0) > 0 || 
+  props.zapCount > 0
+)
+
 const safeEngagementCounts = computed(() => ({
   likes: props.engagementCounts?.likes || 0,
   reposts: props.engagementCounts?.reposts || 0,
@@ -67,31 +74,31 @@ const safeEngagementCounts = computed(() => ({
 </script>
 
 <template>
-  <template v-if="hasEngagement || showAllMetrics">
-    <span v-if="safeEngagementCounts.likes > 0 || showAllMetrics" :class="['flex items-center gap-1', showTooltips ? 'tooltip-container' : '']">
+  <template v-if="hasAnyEngagement || showAllMetrics">
+    <span :class="['flex items-center gap-1', showTooltips ? 'tooltip-container' : '']">
       <IconHeartFilled v-if="safeEngagementCounts.likes > 0" :class="[iconSizeClass, 'text-red-500']" />
       <IconHeart v-else :class="[iconSizeClass, 'text-gray-400']" />
       <span :class="textSize">{{ safeEngagementCounts.likes }}</span>
-      <div v-if="showTooltips" class="custom-tooltip">{{ safeEngagementCounts.likes }} likes</div>
+      <div v-if="showTooltips" class="custom-tooltip">{{ safeEngagementCounts.likes }} {{ safeEngagementCounts.likes <= 1 ? 'like' : 'likes' }}</div>
     </span>
     
-    <span v-if="safeEngagementCounts.reposts > 0 || showAllMetrics" :class="['flex items-center gap-1', showTooltips ? 'tooltip-container' : '']">
+    <span :class="['flex items-center gap-1', showTooltips ? 'tooltip-container' : '']">
       <IconRepeat :class="[iconSizeClass, safeEngagementCounts.reposts > 0 ? 'text-green-500 font-bold' : 'text-gray-400']" />
       <span :class="textSize">{{ safeEngagementCounts.reposts }}</span>
-      <div v-if="showTooltips" class="custom-tooltip">{{ safeEngagementCounts.reposts }} reposts</div>
+      <div v-if="showTooltips" class="custom-tooltip">{{ safeEngagementCounts.reposts }} {{ safeEngagementCounts.reposts <= 1 ? 'repost' : 'reposts' }}</div>
     </span>
     
-    <span v-if="zapCount > 0 || showAllMetrics" :class="['flex items-center gap-1', showTooltips ? 'tooltip-container' : '']">
+    <span :class="['flex items-center gap-1', showTooltips ? 'tooltip-container' : '']">
       <IconBolt :class="[iconSizeClass, zapCount > 0 ? 'text-orange-500 font-bold' : 'text-gray-400']" />
       <span :class="textSize">{{ zapCount }}</span>
-      <div v-if="showTooltips" class="custom-tooltip">{{ zapCount }} zaps</div>
+      <div v-if="showTooltips" class="custom-tooltip">{{ zapCount }} {{ zapCount <= 1 ? 'zap' : 'zaps' }}</div>
     </span>
     
-    <span v-if="safeEngagementCounts.bookmarks > 0 || showAllMetrics" :class="['flex items-center gap-1', showTooltips ? 'tooltip-container' : '']">
+    <span :class="['flex items-center gap-1', showTooltips ? 'tooltip-container' : '']">
       <IconBookmarkFilled v-if="safeEngagementCounts.bookmarks > 0" :class="[iconSizeClass, 'text-blue-500']" />
       <IconBookmark v-else :class="[iconSizeClass, 'text-gray-400']" />
       <span :class="textSize">{{ safeEngagementCounts.bookmarks }}</span>
-      <div v-if="showTooltips" class="custom-tooltip">{{ safeEngagementCounts.bookmarks }} bookmarks</div>
+      <div v-if="showTooltips" class="custom-tooltip">{{ safeEngagementCounts.bookmarks }} {{ safeEngagementCounts.bookmarks <= 1 ? 'bookmark' : 'bookmarks' }}</div>
     </span>
   </template>
   

--- a/src/composables/useEngagementMetrics.js
+++ b/src/composables/useEngagementMetrics.js
@@ -1,0 +1,426 @@
+import { ref, reactive, computed, watch } from 'vue'
+import { useNostrAuth } from './useNostrAuth.js'
+import { nostrRelayManager } from '../utils/nostrRelayManager.js'
+
+const engagementMetrics = reactive(new Map()) 
+const activeSubscriptions = reactive(new Map())
+const isLoading = ref(false)
+const processedEventIds = new Set()
+
+const batchQueue = reactive(new Set())
+const batchTimer = ref(null)
+const BATCH_DELAY = 1000
+const MAX_BATCH_SIZE = 50
+
+export function useEngagementMetrics() {
+  const { currentUser, isAuthenticated } = useNostrAuth()
+
+  const initializeEngagementData = (eventId) => {
+    if (!engagementMetrics.has(eventId)) {
+      engagementMetrics.set(eventId, {
+        likes: [],
+        reposts: [],
+        bookmarks: [],
+        zaps: [],
+        lastFetched: null,
+        isLoading: false
+      })
+    }
+  }
+
+  const createEngagementData = (event, type, targetEventId = null) => {
+    const authorPubkey = event.pubkey
+    const createdAt = event.created_at
+    const eventId = event.id
+
+    const referencedEventId = targetEventId || event.tags.find(tag => tag[0] === 'e')?.[1]
+    
+    if (!referencedEventId) {
+      return null
+    }
+
+    const baseData = {
+      id: eventId,
+      authorPubkey,
+      createdAt,
+      referencedEventId,
+      type
+    }
+
+    switch (type) {
+      case 'like':
+        const reaction = event.content || '+'
+        return {
+          ...baseData,
+          reaction,
+          isPositive: reaction === '+' || reaction === '❤️' || reaction === '🤙' || reaction === '👍'
+        }
+
+      case 'repost':
+        return {
+          ...baseData,
+          content: event.content || '',
+          isQuote: event.content.length > 0
+        }
+
+      case 'bookmark':
+        return {
+          ...baseData,
+          tags: event.tags || []
+        }
+
+      default:
+        return baseData
+    }
+  }
+
+  const processEngagementEvent = (event, targetEventId = null) => {
+    if (processedEventIds.has(event.id)) {
+      return
+    }
+    processedEventIds.add(event.id)
+
+    if ([10001, 10002, 10003, 30001, 30002, 30003].includes(event.kind)) {
+      const bookmarkedEventIds = event.tags.filter(tag => tag[0] === 'e').map(tag => tag[1])
+      
+      const aTagEventIds = []
+      if (targetEventId) {
+        aTagEventIds.push(targetEventId)
+      }
+      
+      const allEventIds = [...bookmarkedEventIds, ...aTagEventIds]
+      
+      if (allEventIds.length > 0) {
+        allEventIds.forEach(eventId => {
+          if (eventId) {
+            initializeEngagementData(eventId)
+            const metrics = engagementMetrics.get(eventId)
+
+            const bookmarkData = {
+              id: `${event.id}-${eventId}`,
+              authorPubkey: event.pubkey,
+              createdAt: event.created_at,
+              referencedEventId: eventId,
+              type: 'bookmark',
+              tags: event.tags || [],
+              listId: event.id
+            }
+
+            const exists = metrics.bookmarks.find(item => item.id === bookmarkData.id)
+            if (!exists) {
+              metrics.bookmarks.unshift(bookmarkData)
+            }
+          }
+        })
+        
+        return
+      }
+    }
+
+    let referencedEventId = targetEventId || event.tags.find(tag => tag[0] === 'e')?.[1]
+    
+    if (!referencedEventId && !targetEventId) {
+      return
+    }
+
+    initializeEngagementData(referencedEventId)
+    const metrics = engagementMetrics.get(referencedEventId)
+
+    let engagementData = null
+    let targetArray = null
+
+    switch (event.kind) {
+      case 7:
+        engagementData = createEngagementData(event, 'like', referencedEventId)
+        targetArray = metrics.likes
+        break
+
+      case 6:
+        engagementData = createEngagementData(event, 'repost', referencedEventId)
+        targetArray = metrics.reposts
+        break
+
+      case 10001:
+      case 10002:
+      case 10003:
+      case 30001:
+      case 30002:
+      case 30003:
+        engagementData = createEngagementData(event, 'bookmark', referencedEventId)
+        targetArray = metrics.bookmarks
+        break
+
+      default:
+        return
+    }
+
+    if (engagementData && targetArray) {
+      const exists = targetArray.find(item => item.id === engagementData.id)
+      if (!exists) {
+        targetArray.unshift(engagementData)
+      }
+    }
+  }
+
+  const fetchEngagementMetricsBatch = async (eventIds) => {
+    if (!eventIds.length || !isAuthenticated.value) return
+
+    const uniqueEventIds = [...new Set(eventIds)]
+
+    uniqueEventIds.forEach(eventId => {
+      initializeEngagementData(eventId)
+      const metrics = engagementMetrics.get(eventId)
+      metrics.isLoading = true
+    })
+
+    try {
+      const filters = [
+        {
+          kinds: [7],
+          "#e": uniqueEventIds,
+          limit: 500
+        },
+        {
+          kinds: [6],
+          "#e": uniqueEventIds,
+          limit: 200
+        },
+        {
+          kinds: [10001, 10002, 10003, 30001, 30002, 30003],
+          "#e": uniqueEventIds,
+          limit: 100
+        }
+      ]
+
+      if (currentUser.value?.pubkey) {
+        filters.push({
+          kinds: [10001, 10002, 10003, 30001, 30002, 30003],
+          authors: [currentUser.value.pubkey],
+          limit: 50
+        })
+      }
+
+      const subscription = nostrRelayManager.subscribeToEvents(filters, {
+        onevent: (event) => {
+          processEngagementEvent(event)
+        },
+        oneose: () => {
+          uniqueEventIds.forEach(eventId => {
+            const metrics = engagementMetrics.get(eventId)
+            if (metrics) {
+              metrics.isLoading = false
+              metrics.lastFetched = new Date().toISOString()
+            }
+          })
+        },
+        onclose: (reason) => {
+          uniqueEventIds.forEach(eventId => {
+            const metrics = engagementMetrics.get(eventId)
+            if (metrics) {
+              metrics.isLoading = false
+            }
+          })
+        }
+      })
+
+      const subscriptionId = `engagement-batch-${Date.now()}`
+      activeSubscriptions.set(subscriptionId, subscription)
+
+      setTimeout(() => {
+        if (subscription) {
+          subscription.close()
+          activeSubscriptions.delete(subscriptionId)
+        }
+      }, 30000)
+
+    } catch (error) {
+      console.error('Failed to fetch engagement metrics:', error)
+      
+      uniqueEventIds.forEach(eventId => {
+        const metrics = engagementMetrics.get(eventId)
+        if (metrics) {
+          metrics.isLoading = false
+        }
+      })
+    }
+  }
+
+  const queueEngagementFetch = (eventId) => {
+    if (!eventId || activeSubscriptions.has(`engagement-${eventId}`)) {
+      return
+    }
+
+    batchQueue.add(eventId)
+
+    if (batchTimer.value) {
+      clearTimeout(batchTimer.value)
+    }
+
+    batchTimer.value = setTimeout(() => {
+      if (batchQueue.size > 0) {
+        const eventIds = Array.from(batchQueue)
+        batchQueue.clear()
+        
+        const chunks = []
+        for (let i = 0; i < eventIds.length; i += MAX_BATCH_SIZE) {
+          chunks.push(eventIds.slice(i, i + MAX_BATCH_SIZE))
+        }
+
+        chunks.forEach((chunk, index) => {
+          setTimeout(() => {
+            fetchEngagementMetricsBatch(chunk)
+          }, index * 500)
+        })
+      }
+    }, BATCH_DELAY)
+  }
+
+  const startEngagementTracking = (eventId) => {
+    if (!eventId) return
+
+    if (activeSubscriptions.has(`engagement-${eventId}`)) {
+      return
+    }
+
+    const existingMetrics = engagementMetrics.get(eventId)
+    if (existingMetrics?.lastFetched) {
+      const lastFetched = new Date(existingMetrics.lastFetched)
+      const now = new Date()
+      const timeDiff = now - lastFetched
+      if (timeDiff < 5 * 60 * 1000) {
+        return
+      }
+    }
+
+    queueEngagementFetch(eventId)
+  }
+
+  const getEngagementMetrics = (eventId) => {
+    if (!eventId) return null
+    return engagementMetrics.get(eventId) || null
+  }
+
+  const getEngagementCounts = (eventId) => {
+    const metrics = getEngagementMetrics(eventId)
+    if (!metrics) {
+      return {
+        likes: 0,
+        reposts: 0,
+        bookmarks: 0,
+        totalEngagement: 0
+      }
+    }
+
+    const likes = metrics.likes.length
+    const reposts = metrics.reposts.length
+    const bookmarks = metrics.bookmarks.length
+
+    return {
+      likes,
+      reposts,
+      bookmarks,
+      totalEngagement: likes + reposts + bookmarks
+    }
+  }
+
+  const getCombinedEngagement = (eventId, zapData = null) => {
+    const engagementCounts = getEngagementCounts(eventId)
+    const zapCount = zapData?.count || 0
+    const zapAmount = zapData?.totalAmount || 0
+
+    return {
+      ...engagementCounts,
+      zaps: zapCount,
+      zapAmount,
+      totalEngagement: engagementCounts.totalEngagement + zapCount
+    }
+  }
+
+  const cleanup = () => {
+    activeSubscriptions.forEach((subscription) => {
+      try {
+        if (subscription && typeof subscription.close === 'function') {
+          subscription.close()
+        }
+      } catch (error) {
+        console.warn('Error closing engagement subscription:', error)
+      }
+    })
+    
+    activeSubscriptions.clear()
+    batchQueue.clear()
+    
+    if (batchTimer.value) {
+      clearTimeout(batchTimer.value)
+      batchTimer.value = null
+    }
+  }
+
+  const allEngagementMetrics = computed(() => {
+    const result = {}
+    engagementMetrics.forEach((value, key) => {
+      result[key] = value
+    })
+    return result
+  })
+
+  const startLongFormContentTracking = (eventId, pubkey, dTag) => {
+    if (!eventId || !pubkey || !dTag) {
+      startEngagementTracking(eventId)
+      return
+    }
+
+    startEngagementTracking(eventId)
+
+    const aTagIdentifier = `30023:${pubkey}:${dTag}`
+
+    if (!activeSubscriptions.has(`engagement-a-${aTagIdentifier}`)) {
+      const aTagFilters = [
+        {
+          kinds: [7], 
+          "#a": [aTagIdentifier],
+          limit: 200
+        },
+        {
+          kinds: [6], 
+          "#a": [aTagIdentifier],
+          limit: 100
+        },
+        {
+          kinds: [10001, 10002, 10003, 30001, 30002, 30003], 
+          "#a": [aTagIdentifier],
+          limit: 50
+        }
+      ]
+
+      const subscription = nostrRelayManager.subscribeToEvents(aTagFilters, {
+        onevent: (event) => {
+          processEngagementEvent(event, eventId) 
+        },
+        oneose: () => {
+          console.log('📡 A-tag subscription EOSE for:', aTagIdentifier)
+        },
+        onclose: (reason) => {
+          activeSubscriptions.delete(`engagement-a-${aTagIdentifier}`)
+        }
+      })
+
+      activeSubscriptions.set(`engagement-a-${aTagIdentifier}`, subscription)
+    }
+  }
+
+  return {
+    startEngagementTracking,
+    startLongFormContentTracking,
+    getEngagementMetrics,
+    getEngagementCounts,
+    getCombinedEngagement,
+    cleanup,
+
+    allEngagementMetrics,
+    isLoading,
+
+    activeSubscriptions: computed(() => Array.from(activeSubscriptions.keys())),
+    processedEventIds: computed(() => processedEventIds.size)
+  }
+}

--- a/src/pages/Content.vue
+++ b/src/pages/Content.vue
@@ -737,9 +737,9 @@ onUnmounted(() => {
                     <span class="text-sm font-medium text-gray-600">Engagement</span>
                     <div class="flex items-center gap-2">
                       <EngagementMetrics 
-                        :key="`sidebar-engagement-${selectedContent.id}-${getEngagementCounts(selectedContent.nostrEventId).totalEngagement}-${getZapCount(selectedContent.nostrEventId)}`"
+                        :key="`sidebar-engagement-${selectedContent.id}-${getEngagementCounts(selectedContent.nostrEventId).totalEngagement}-${selectedContent.zapCount || 0}`"
                         :engagement-counts="getEngagementCounts(selectedContent.nostrEventId)"
-                        :zap-count="getZapCount(selectedContent.nostrEventId)"
+                        :zap-count="selectedContent.zapCount || 0"
                         size="default"
                         text-size="text-xs"
                         :show-all-metrics="false"

--- a/src/pages/Content.vue
+++ b/src/pages/Content.vue
@@ -22,11 +22,13 @@ import { useContent } from '../composables/useContent.js'
 import { useContentZaps } from '../composables/useContentZaps.js'
 import { useNostrAuth } from '../composables/useNostrAuth.js'
 import { useNostrLongForm } from '../composables/useNostrLongForm.js'
+import { useEngagementMetrics } from '../composables/useEngagementMetrics.js'
 import { generateFallbackAvatar } from '../composables/useContentZaps.js'
 import ContentStats from '../components/ContentStats.vue'
 import ContentList from '../components/ContentList.vue'
 import ContentForm from '../components/ContentForm.vue'
 import ContentPerformance from '../components/ContentPerformance.vue'
+import EngagementMetrics from '../components/EngagementMetrics.vue'
 
 const { isAuthenticated, currentUser, userProfile, login } = useNostrAuth()
 
@@ -80,6 +82,8 @@ if (!contentForm.description) {
 }
 
 const { getAllContentZaps } = useContentZaps()
+
+const { getEngagementCounts } = useEngagementMetrics()
 
 
 const handleCreateContent = async () => {
@@ -726,6 +730,24 @@ onUnmounted(() => {
                 <div class="flex items-center justify-between">
                   <span class="text-sm text-gray-600">Revenue</span>
                   <span class="font-medium text-orange-600">{{ (selectedContent.revenue || 0).toLocaleString() }} sats</span>
+                </div>
+                
+                <div v-if="selectedContent.nostrEventId" class="border-t pt-3 mt-3">
+                  <div class="flex items-center justify-between">
+                    <span class="text-sm font-medium text-gray-600">Engagement</span>
+                    <div class="flex items-center gap-2">
+                      <EngagementMetrics 
+                        :key="`sidebar-engagement-${selectedContent.id}-${getEngagementCounts(selectedContent.nostrEventId).totalEngagement}-${getZapCount(selectedContent.nostrEventId)}`"
+                        :engagement-counts="getEngagementCounts(selectedContent.nostrEventId)"
+                        :zap-count="getZapCount(selectedContent.nostrEventId)"
+                        size="default"
+                        text-size="text-xs"
+                        :show-all-metrics="false"
+                        :show-no-engagement-text="true"
+                        :show-tooltips="false"
+                      />
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/pages/Notes.vue
+++ b/src/pages/Notes.vue
@@ -28,8 +28,10 @@ import {
 import { useNostrNotes } from '../composables/useNostrNotes.js'
 import { useNostrAuth } from '../composables/useNostrAuth.js'
 import { useContentZaps } from '../composables/useContentZaps.js'
+import { useEngagementMetrics } from '../composables/useEngagementMetrics.js'
 import { useBtcPrice } from '../composables/useBtcPrice.js'
 import { generateFallbackAvatar } from '../composables/useContentZaps.js'
+import EngagementMetrics from '../components/EngagementMetrics.vue'
 
 const { isAuthenticated, currentUser, userProfile, login } = useNostrAuth()
 
@@ -63,6 +65,12 @@ const {
   getZapCount,
   getAllContentZaps
 } = useContentZaps()
+
+const {
+  startEngagementTracking,
+  getEngagementCounts,
+  cleanup: cleanupEngagement
+} = useEngagementMetrics()
 
 // Use BTC price composable
 const { satsToUSD, formatUSD } = useBtcPrice()
@@ -150,6 +158,24 @@ const noteStats = computed(() => {
     return sum + getTotalZapAmount(note.id)
   }, 0)
   
+  const totalLikes = notes.value.reduce((sum, note) => {
+    return sum + getEngagementCounts(note.id).likes
+  }, 0)
+  
+  const totalReposts = notes.value.reduce((sum, note) => {
+    return sum + getEngagementCounts(note.id).reposts
+  }, 0)
+  
+  const totalBookmarks = notes.value.reduce((sum, note) => {
+    return sum + getEngagementCounts(note.id).bookmarks
+  }, 0)
+  
+  const totalZapCount = notes.value.reduce((sum, note) => {
+    return sum + getZapCount(note.id)
+  }, 0)
+  
+  const totalEngagement = totalLikes + totalReposts + totalBookmarks
+  
   return {
     total: notes.value.length,
     thisWeek: notes.value.filter(note => {
@@ -157,7 +183,12 @@ const noteStats = computed(() => {
       const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
       return noteDate > weekAgo
     }).length,
-    totalZapRevenue
+    totalZapRevenue,
+    totalLikes,
+    totalReposts,
+    totalBookmarks,
+    totalZapCount,
+    totalEngagement
   }
 })
 
@@ -240,19 +271,32 @@ onMounted(() => {
   // Expose debug function globally for console access
   window.debugNotes = debugState
   
-  // Start tracking zaps for all notes
-  if (isAuthenticated.value && notes.value.length > 0) {
-    notes.value.forEach(note => {
-      startZapTracking(note.id)
-    })
+  // Start tracking zaps and engagement for all notes
+  if (isAuthenticated.value) {
+    if (notes.value.length > 0) {
+      notes.value.forEach(note => {
+        startZapTracking(note.id)
+        startEngagementTracking(note.id)
+      })
+    }
+    
+    setTimeout(() => {
+      if (notes.value.length > 0) {
+        notes.value.forEach(note => {
+          startZapTracking(note.id)
+          startEngagementTracking(note.id)
+        })
+      }
+    }, 1000)
   }
 })
 
-// Watch for notes changes to track zaps on new notes
+// Watch for notes changes to track zaps and engagement on new notes
 watch(notes, (newNotes) => {
   if (isAuthenticated.value && newNotes.length > 0) {
     newNotes.forEach(note => {
       startZapTracking(note.id)
+      startEngagementTracking(note.id)
     })
   }
 }, { deep: true })
@@ -326,6 +370,7 @@ const handleEmojiSelect = (emoji) => {
 onUnmounted(() => {
   // Clean up subscriptions when component unmounts
   cleanup()
+  cleanupEngagement()
   // Remove global debug function
   delete window.debugNotes
 })
@@ -416,7 +461,7 @@ onUnmounted(() => {
       <!-- Notes List View -->
       <div v-if="currentView === 'list'">
         <!-- Stats Cards -->
-        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
           <!-- Total Zap Revenue Card - Now Highlighted -->
           <div class="bg-gradient-to-r from-orange-400 to-amber-400 text-white p-4 rounded-xl shadow-sm">
             <div class="flex flex-col">
@@ -463,6 +508,34 @@ onUnmounted(() => {
               <IconBolt class="w-8 h-8 text-purple-600" />
             </div>
           </div>
+          
+          <!-- Total Engagement Card -->
+          <div class="bg-white p-4 rounded-xl border border-orange-100/50 shadow-sm">
+            <div class="flex flex-col">
+              <p class="text-gray-600 text-sm mb-1">Engagement</p>
+              <p class="text-2xl font-bold text-gray-900">{{ noteStats.totalEngagement.toLocaleString() }}</p>
+              <div class="flex items-center gap-2 mt-1 text-xs text-gray-500">
+                <EngagementMetrics 
+                  :key="`stats-${noteStats.totalEngagement}-${noteStats.totalZapCount}`"
+                  :engagement-counts="{
+                    likes: noteStats.totalLikes,
+                    reposts: noteStats.totalReposts,
+                    bookmarks: noteStats.totalBookmarks,
+                    totalEngagement: noteStats.totalEngagement
+                  }"
+                  :zap-count="noteStats.totalZapCount"
+                  size="medium"
+                  text-size="text-sm"
+                  :show-all-metrics="false"
+                  :show-no-engagement-text="true"
+                  :show-tooltips="false"
+                />
+              </div>
+            </div>
+            <div class="flex justify-end">
+              <IconUsers class="w-8 h-8 text-gray-600" />
+            </div>
+          </div>
         </div>
 
         <!-- Notes List -->
@@ -497,18 +570,18 @@ onUnmounted(() => {
             >
               <div class="flex items-start justify-between gap-3">
                 <div class="flex-1 min-w-0 space-y-2">
-                  <div class="flex items-center gap-2">
+                  <div class="flex items-center gap-2 mb-2">
                     <h4 class="font-semibold text-gray-900 truncate">
                       {{ note.title }}
                     </h4>
                     <span v-if="getZapCount(note.id) > 0" 
                           class="flex items-center space-x-1 bg-orange-100 text-orange-700 px-2 py-0.5 rounded-full text-xs">
-                      <IconBolt class="w-3 h-3" />
+                      <IconBolt class="w-3 h-3 text-orange-600 font-bold" />
                       <span>{{ formatZapAmount(getTotalZapAmount(note.id)) }}</span>
                     </span>
                   </div>
                   
-                  <p class="text-sm text-gray-600 line-clamp-2">
+                  <p class="text-sm text-gray-600 line-clamp-2 mb-3">
                     {{ note.preview }}
                   </p>
                   
@@ -517,6 +590,17 @@ onUnmounted(() => {
                       <IconCalendar class="w-3 h-3" />
                       <span>{{ formatDate(note.created_at) }}</span>
                     </span>
+                    
+                    <EngagementMetrics 
+                      :key="`engagement-${note.id}-${getEngagementCounts(note.id).totalEngagement}-${getZapCount(note.id)}`"
+                      :engagement-counts="getEngagementCounts(note.id)"
+                      :zap-count="getZapCount(note.id)"
+                      size="default"
+                      text-size="text-xs"
+                      :show-all-metrics="false"
+                      :show-no-engagement-text="true"
+                    />
+                    
                     <span v-if="note.hashtags && note.hashtags.length > 0" class="flex items-center gap-1">
                       <IconHash class="w-3 h-3" />
                       <span>{{ note.hashtags.slice(0, 2).join(', ') }}</span>
@@ -693,6 +777,14 @@ onUnmounted(() => {
                     <IconUser class="w-4 h-4" />
                     <span>{{ userProfile?.name || 'You' }}</span>
                   </span>
+                  <EngagementMetrics 
+                    :key="`detail-${selectedNote.id}-${getEngagementCounts(selectedNote.id).totalEngagement}-${getZapCount(selectedNote.id)}`"
+                    :engagement-counts="getEngagementCounts(selectedNote.id)"
+                    :zap-count="getZapCount(selectedNote.id)"
+                    size="default"
+                    text-size="text-sm"
+                    :show-no-engagement-text="true"
+                  />
                 </div>
               </div>
               

--- a/src/pages/Notes.vue
+++ b/src/pages/Notes.vue
@@ -783,6 +783,7 @@ onUnmounted(() => {
                     :zap-count="getZapCount(selectedNote.id)"
                     size="default"
                     text-size="text-sm"
+                    :show-all-metrics="false"
                     :show-no-engagement-text="true"
                   />
                 </div>


### PR DESCRIPTION
## What's New? 🎉

We've added **engagement metrics** to show how people interact with your content beyond just zaps! Now you can see likes ❤️, reposts 🔁, and bookmarks 📑 for both your Notes and Content.

## Closed: #42 

## What Changed? 📝

### Notes Tab
- Added engagement metrics below each note title
- Shows live counts for likes, reposts, bookmarks, and zaps
- Displays "No Engagement Yet" when there's no activity
- Real-time updates when someone interacts with your notes

### Content Tab  
- Added engagement metrics in the sidebar performance section
- Clean horizontal layout that fits nicely with other stats
- Same live tracking and display logic as Notes

### Technical Stuff
- Created reusable `EngagementMetrics` component
- Smart relay batching to avoid overwhelming Nostr relays
- Fixed Vue reactivity issues for smooth real-time updates
- Added profile caching for better performance

## How It Works 🔧

The system now tracks these Nostr events:
- **kind:7** = Likes/Reactions ❤️
- **kind:6** = Reposts/Quotes 🔁  
- **kind:10002/30001** = Bookmarks 📑
- **kind:9735** = Zaps ⚡

When someone interacts with your content on Primal.net or other Nostr clients, you'll see the counts update in real-time!

## Testing ✅

- ✅ Engagement metrics show correctly in Notes tab
- ✅ Engagement metrics show correctly in Content preview
- ✅ Real-time updates work when users interact on Primal.net
- ✅ "No Engagement Yet" displays when there's no activity
- ✅ Smart batching prevents relay overload

## Screenshots 📸

`Notes`:

<img width="1920" height="980" alt="image" src="https://github.com/user-attachments/assets/54a210e6-0e70-498f-9d31-096ca2fc2e94" />

<img width="1919" height="973" alt="image" src="https://github.com/user-attachments/assets/37457348-862d-4583-b92f-6089a106d074" />

<img width="1920" height="977" alt="image" src="https://github.com/user-attachments/assets/fc4f59cc-cc93-435b-be55-416d9e420b2a" />


`Content`:

<img width="1914" height="979" alt="image" src="https://github.com/user-attachments/assets/c9e92d36-f236-4d87-a9a9-745c5b04be3f" />

<img width="1920" height="923" alt="image" src="https://github.com/user-attachments/assets/41ceb30e-312b-4785-83bd-20f028293d9a" />

## Demo: 