### PR TITLE
Improve relay handling & client-side resilience

### DIFF
--- a/src/composables/useNostrAuth.js
+++ b/src/composables/useNostrAuth.js
@@ -167,6 +167,49 @@ const fetchAndStoreProfile = async (pubkey) => {
   }
 }
 
+// Fetch user's published relay list (NIP-65 / kind 10002) and merge into userRelays
+const fetchAndMergeUserRelays = async (pubkey) => {
+  if (!pubkey) return
+  try {
+    console.log('Fetching user relays (NIP-65) for', pubkey.substring(0,8) + '...')
+    const relayEvent = await nostrRelayManager.getEvent({ authors: [pubkey], kinds: [10002], limit: 1 })
+    if (!relayEvent || !relayEvent.tags) return
+
+    const profileRelays = relayEvent.tags
+      .filter(t => Array.isArray(t) && t[0] === 'r' && typeof t[1] === 'string')
+      .map(t => t[1])
+      .filter(Boolean)
+
+    if (profileRelays.length === 0) return
+
+    // Merge without duplicates
+    const existing = new Set(userRelays.value.map(r => r.url))
+    let added = 0
+    profileRelays.forEach(url => {
+      if (!existing.has(url)) {
+        userRelays.value.push({ url, status: 'disconnected', read: true, write: true })
+        existing.add(url)
+        added++
+      }
+    })
+
+    if (added > 0) {
+      saveRelaysToStorage(userRelays.value)
+      try {
+        // re-init relay manager with updated list (best-effort)
+        await nostrRelayManager.initialize(userRelays.value)
+      } catch (e) {
+        console.warn('nostrRelayManager.initialize failed after merging relays', e)
+      }
+      // sync statuses into UI state
+      syncRelayStatuses()
+      console.log(`Merged ${added} relays from NIP-65 profile`)
+    }
+  } catch (error) {
+    console.warn('Failed to fetch or merge NIP-65 relays:', error)
+  }
+}
+
 // Create user data from profile event
 const createUserData = (pubkey, profileEvent) => {
   try {
@@ -433,6 +476,9 @@ const login = () => {
           
           // Fetch and store profile for new user
           const userData = await fetchAndStoreProfile(pubkey)
+
+          // Fetch and merge any user-published relays (NIP-65)
+          await fetchAndMergeUserRelays(pubkey)
           
           // Start listening for user events
           startUserEventListener(pubkey)
@@ -557,6 +603,8 @@ const initAuthAndRelays = async () => {
     
     // If user exists, start listening for their events
     if (hasUser && currentUser.value) {
+      // Merge user's published relays (NIP-65) on init
+      await fetchAndMergeUserRelays(currentUser.value.pubkey)
       setTimeout(() => {
         startUserEventListener(currentUser.value.pubkey)
       }, 2000)

--- a/src/utils/nostrRelayManager.js
+++ b/src/utils/nostrRelayManager.js
@@ -7,9 +7,14 @@ class NostrRelayManager {
     this.pool = new SimplePool()
     this.relayConnections = new Map() // Map of URL -> connection info
     this.relayStatuses = new Map() // Map of URL -> status info
+    this.relayMeta = new Map() // Map of URL -> { successes, failures, rtt, score, lastFailure, attempts }
+    this.relayMetrics = new Map() // Map of URL -> telemetry counts
     this.connectionPromises = new Map() // Map of URL -> connection promise
     this.eventListeners = new Set()
     this.isInitialized = false
+  // Subscription registry to dedupe identical subscriptions and forward callbacks
+  // key -> { sub: subscriptionObject, listeners: Set<{onevent, oneose, onclose}>, refCount }
+  this.subscriptionRegistry = new Map()
     
     // Default reliable relays
     this.defaultRelays = [
@@ -27,6 +32,18 @@ class NostrRelayManager {
     this.retryDelay = 2000 // 2 seconds
     this.healthCheckInterval = 30000 // 30 seconds
     this.healthCheckTimer = null
+    // Publish queue persisted to localStorage
+    this.PUBLISH_QUEUE_KEY = 'zap_pending_publishes'
+    this.publishQueue = []
+    // Rate limiting / throttling parameters
+    this.REQUEST_WINDOW_MS = 60_000 // 1 minute window
+    this.MAX_REQUESTS_PER_WINDOW = 30 // max requests per relay per window
+    this.PAUSE_BASE_MS = 30_000 // base pause for rate-limit violations
+    // Caches
+    this.profileCache = new Map() // pubkey -> { profile, ts }
+    this.eventCache = new Map() // cacheKey -> { events, ts }
+    this.PROFILE_CACHE_TTL = 60 * 60 * 1000 // 1hr
+    this.EVENT_CACHE_TTL = 5 * 60 * 1000 // 5min
   }
 
   // Initialize the relay manager
@@ -40,11 +57,23 @@ class NostrRelayManager {
     
     try {
       // Combine user relays with defaults, prioritizing user relays
-      const allRelays = this.mergeRelayLists(userRelays, this.defaultRelays)
+  const allRelays = this.mergeRelayLists(userRelays, this.defaultRelays)
+  // persist user relays for future sessions
+  try { localStorage.setItem('nostrRelays', JSON.stringify(userRelays || [])) } catch (e) {}
       
+      // Initialize relay meta & metrics entries
+      allRelays.forEach(r => {
+        const url = r.url || r
+        if (!this.relayMeta.has(url)) this.relayMeta.set(url, { url, successes: 0, failures: 0, rtt: Infinity, score: 0, lastFailure: 0, attempts: 0 })
+        if (!this.relayMetrics.has(url)) this.relayMetrics.set(url, { published: 0, publishFailed: 0, reads: 0, readFailed: 0 })
+      })
+
       // Connect to all relays
       await this.connectToRelays(allRelays)
-      
+
+      // Load publish queue from storage
+      try { this.publishQueue = JSON.parse(localStorage.getItem(this.PUBLISH_QUEUE_KEY) || '[]') } catch (e) { this.publishQueue = [] }
+
       // Start health check monitoring
       this.startHealthCheck()
       
@@ -74,7 +103,9 @@ class NostrRelayManager {
     
     // Override with user relays
     userRelays.forEach(relay => {
-      relayMap.set(relay.url, relay)
+      // allow either string or {url,read,write}
+      const entry = typeof relay === 'string' ? { url: relay, read: true, write: true } : relay
+      relayMap.set(entry.url, entry)
     })
     
     return Array.from(relayMap.values())
@@ -142,8 +173,8 @@ class NostrRelayManager {
     try {
       console.log(`🔌 Attempting to connect to ${url} (attempt ${retryCount + 1})`)
       
-      // Use pool.ensureRelay which returns a promise that resolves when connected
-      const relayPromise = this.pool.ensureRelay(url)
+  // Use pool.ensureRelay which returns a promise that resolves when connected
+  const relayPromise = this.pool.ensureRelay(url)
       
       // Add timeout to the connection attempt
       const timeoutPromise = new Promise((_, reject) => 
@@ -159,9 +190,17 @@ class NostrRelayManager {
         config,
         connectedAt: new Date().toISOString()
       })
-      
+
+      // update meta success
+      const meta = this.relayMeta.get(url) || { url }
+      meta.successes = (meta.successes || 0) + 1
+      meta.rtt = (Date.now() - (meta._lastProbeStart || Date.now())) || 0
+      meta.lastFailure = meta.lastFailure || 0
+      meta.attempts = 0
+      this.relayMeta.set(url, meta)
+
       this.setRelayStatus(url, 'connected', config)
-      
+
       console.log(`✅ Successfully connected to ${url}`)
       this.emitEvent('relayConnected', { url, config })
       
@@ -170,10 +209,17 @@ class NostrRelayManager {
     } catch (error) {
       console.warn(`❌ Connection attempt ${retryCount + 1} failed for ${url}:`, error.message)
       
-      // Retry logic
+      // Retry logic with exponential backoff
+      const meta = this.relayMeta.get(url) || { url, attempts: 0 }
+      meta.failures = (meta.failures || 0) + 1
+      meta.attempts = (meta.attempts || 0) + 1
+      meta.lastFailure = Date.now()
+      this.relayMeta.set(url, meta)
+
       if (retryCount < this.maxRetries) {
-        console.log(`🔄 Retrying connection to ${url} in ${this.retryDelay}ms...`)
-        await new Promise(resolve => setTimeout(resolve, this.retryDelay))
+        const backoff = this.retryDelay * Math.pow(2, retryCount)
+        console.log(`🔄 Retrying connection to ${url} in ${backoff}ms...`)
+        await new Promise(resolve => setTimeout(resolve, backoff))
         return this._attemptConnection(url, config, retryCount + 1)
       } else {
         this.setRelayStatus(url, 'failed', config, error.message)
@@ -214,6 +260,8 @@ class NostrRelayManager {
       lastUpdated: new Date().toISOString(),
       lastConnected: status === 'connected' ? new Date().toISOString() : currentStatus.lastConnected
     })
+    // ensure meta entry exists
+    if (!this.relayMeta.has(url)) this.relayMeta.set(url, { url, successes: 0, failures: 0, rtt: Infinity, score: 0, lastFailure: 0, attempts: 0 })
   }
 
   // Get all relay statuses
@@ -236,6 +284,90 @@ class NostrRelayManager {
     return this.getConnectedRelays().filter(relay => relay.config?.read === true)
   }
 
+  // Select relays for read operations based on score and config
+  selectRelaysForRead(limit = 4) {
+    // prefer read-enabled connected relays
+  const readRelays = this.getReadRelays().map(r => r.url)
+    if (!readRelays || readRelays.length === 0) return []
+
+    // combine scores from relayMeta
+  const now = Date.now()
+  const metas = Array.from(this.relayMeta.values()).filter(m => readRelays.includes(m.url) && (!(m.pausedUntil) || (m.pausedUntil <= now)))
+    metas.sort((a,b) => (b.score || 0) - (a.score || 0))
+    const selected = metas.slice(0, limit).map(m => m.url)
+    // fallback: if not enough scored relays, fill from readRelays
+    if (selected.length < limit) {
+      const fill = readRelays.filter(u => !selected.includes(u)).slice(0, limit - selected.length)
+      return selected.concat(fill)
+    }
+    return selected
+  }
+
+  // Record a request against a relay and apply pause/backoff if threshold exceeded
+  recordRelayRequest(url) {
+    if (!url) return
+    const now = Date.now()
+    const meta = this.relayMeta.get(url) || { url, requestTimestamps: [], attempts: 0 }
+    meta.requestTimestamps = (meta.requestTimestamps || []).filter(ts => (now - ts) <= this.REQUEST_WINDOW_MS)
+    meta.requestTimestamps.push(now)
+    // if exceeded
+    if ((meta.requestTimestamps.length || 0) > this.MAX_REQUESTS_PER_WINDOW) {
+      meta.attempts = (meta.attempts || 0) + 1
+      const pause = Math.min(5 * this.PAUSE_BASE_MS, this.PAUSE_BASE_MS * Math.pow(2, meta.attempts - 1))
+      meta.pausedUntil = now + pause
+      this.emitEvent('relayRateLimited', { url, pausedUntil: meta.pausedUntil })
+      console.warn(`Relay ${url} paused for ${pause}ms due to request rate`) 
+    }
+    this.relayMeta.set(url, meta)
+  }
+
+  // Promise timeout helper
+  withTimeout(promise, ms) {
+    return Promise.race([
+      promise,
+      new Promise((_, rej) => setTimeout(() => rej(new Error('timeout')), ms))
+    ])
+  }
+
+  // Enqueue a publish for retry later; persisted to localStorage
+  enqueuePublish(event) {
+    try {
+      const item = { event, attempts: 0, lastTried: 0 }
+      this.publishQueue.push(item)
+      localStorage.setItem(this.PUBLISH_QUEUE_KEY, JSON.stringify(this.publishQueue))
+      console.log('🗃️ Enqueued publish for later', event.id)
+    } catch (e) {
+      console.warn('Failed to enqueue publish', e)
+    }
+  }
+
+  // Flush publish queue with simple backoff and retry policies
+  async flushPublishQueue() {
+    if (!this.publishQueue || this.publishQueue.length === 0) return
+    if (!this.isInitialized) return
+
+    const queue = [...this.publishQueue]
+    for (const item of queue) {
+      // backoff check
+      const now = Date.now()
+      const wait = Math.min(60_000, 1000 * Math.pow(2, item.attempts || 0))
+      if (item.lastTried && (now - item.lastTried) < wait) continue
+
+      try {
+        await this.publishEvent(item.event)
+        // remove from queue
+        this.publishQueue = this.publishQueue.filter(q => q !== item)
+        localStorage.setItem(this.PUBLISH_QUEUE_KEY, JSON.stringify(this.publishQueue))
+        console.log('✅ Flushed queued publish', item.event.id)
+      } catch (e) {
+        item.attempts = (item.attempts || 0) + 1
+        item.lastTried = Date.now()
+        localStorage.setItem(this.PUBLISH_QUEUE_KEY, JSON.stringify(this.publishQueue))
+        console.warn('Publish retry failed for', item.event.id)
+      }
+    }
+  }
+
   // Publish event to write relays using the correct pool.publish API
   async publishEvent(event, targetRelays = null) {
     if (!this.isInitialized) {
@@ -248,61 +380,72 @@ class NostrRelayManager {
       throw new Error('Invalid event signature')
     }
 
-    // Determine which relays to use
-    const relaysToUse = targetRelays || this.getWriteRelays()
-    
-    if (relaysToUse.length === 0) {
-      throw new Error('No write-enabled relays available')
+    // Determine which relays to use: prefer healthy write-enabled relays
+    const writeRelays = this.getWriteRelays()
+    const preferred = (targetRelays && targetRelays.length) ? targetRelays.map(r => (r.url? r.url: r)) : writeRelays.map(r => r.url)
+    const healthy = Array.from(this.relayMeta.values()).filter(m => m && (m.score || 0) > 0).sort((a,b)=> (b.score||0)-(a.score||0)).map(m=>m.url)
+    const relayUrls = preferred.length ? preferred.filter(u=>u) : healthy
+    const targets = relayUrls.length ? relayUrls : writeRelays.map(r=>r.url)
+
+    if (targets.length === 0) {
+      // enqueue for later if no write relays
+      this.enqueuePublish(event)
+      throw new Error('No write-enabled relays available; event queued')
     }
 
-    const relayUrls = relaysToUse.map(relay => relay.url)
-    console.log(`📤 Publishing event ${event.id} to ${relayUrls.length} relays:`, relayUrls)
+    console.log(`📤 Publishing event ${event.id} to ${targets.length} relays:` , targets)
 
     try {
-      // Use pool.publish which returns an array of promises
-      const publishPromises = this.pool.publish(relayUrls, event)
-      
-      // Wait for all publish attempts with timeout
-      const timeoutPromise = new Promise((_, reject) => 
-        setTimeout(() => reject(new Error('Publishing timeout after 30 seconds')), 30000)
-      )
-      
-      const results = await Promise.race([
-        Promise.allSettled(publishPromises),
-        timeoutPromise
-      ])
+      const publishPromises = this.pool.publish(targets, event)
 
-      // Count successful publications
-      const successful = results.filter(result => result.status === 'fulfilled')
-      const failed = results.filter(result => result.status === 'rejected')
+      // attach callbacks for nostr-tools publish object
+      if (publishPromises && typeof publishPromises.on === 'function') {
+        publishPromises.on('ok', (relay)=> {
+          const m = this.relayMeta.get(relay) || { url: relay }
+          m.successes = (m.successes||0)+1
+          this.relayMeta.set(relay, m)
+          const metrics = this.relayMetrics.get(relay) || { published:0 }
+          metrics.published = (metrics.published||0) + 1
+          this.relayMetrics.set(relay, metrics)
+        })
+        publishPromises.on('failed', (relay)=> {
+          const m = this.relayMeta.get(relay) || { url: relay }
+          m.failures = (m.failures||0)+1
+          m.lastFailure = Date.now()
+          this.relayMeta.set(relay, m)
+          const metrics = this.relayMetrics.get(relay) || { publishFailed:0 }
+          metrics.publishFailed = (metrics.publishFailed||0) + 1
+          this.relayMetrics.set(relay, metrics)
+        })
+      }
 
-      console.log(`📊 Publishing results: ${successful.length} successful, ${failed.length} failed`)
+      // Wait for publish promises to settle (nostr-tools may return an array of promises)
+      let results = []
+      try { results = await Promise.allSettled(publishPromises) } catch(e) { results = [] }
 
-      // Log failed attempts for debugging
-      failed.forEach((result, index) => {
-        console.warn(`❌ Failed to publish to ${relayUrls[index]}:`, result.reason?.message)
-      })
+      const successful = results.filter(r => r.status === 'fulfilled')
+      const failed = results.filter(r => r.status === 'rejected')
 
       if (successful.length === 0) {
-        throw new Error('Failed to publish to any relays')
+        // enqueue for retry
+        this.enqueuePublish(event)
+        this.emitEvent('publishFailed', { eventId: event.id, error: 'No successful publishes; queued' })
+        throw new Error('Failed to publish to any relays; queued for retry')
       }
 
       this.emitEvent('eventPublished', {
         eventId: event.id,
         successfulRelays: successful.length,
         failedRelays: failed.length,
-        totalRelays: relayUrls.length
+        totalRelays: targets.length
       })
 
-      return {
-        successful: successful.length,
-        failed: failed.length,
-        total: relayUrls.length
-      }
-
+      return { successful: successful.length, failed: failed.length, total: targets.length }
     } catch (error) {
       console.error('❌ Failed to publish event:', error)
-      this.emitEvent('publishFailed', { eventId: event.id, error: error.message })
+      // enqueue on unexpected error
+      this.enqueuePublish(event)
+      this.emitEvent('publishFailed', { eventId: event.id, error: error?.message || String(error) })
       throw error
     }
   }
@@ -312,20 +455,75 @@ class NostrRelayManager {
     if (!this.isInitialized) {
       throw new Error('Relay manager not initialized')
     }
+    const selected = this.selectRelaysForRead(options.limit || 6)
+    if (!selected || selected.length === 0) throw new Error('No read-enabled relays available')
 
-    const readRelays = this.getReadRelays()
-    if (readRelays.length === 0) {
-      throw new Error('No read-enabled relays available')
+    // Normalize filters into a key to dedupe subscriptions
+    const key = this._normalizeSubscriptionKey(filters, selected)
+    if (this.subscriptionRegistry.has(key)) {
+      // reuse existing subscription: add listeners and bump refCount
+      const entry = this.subscriptionRegistry.get(key)
+      entry.refCount = (entry.refCount || 1) + 1
+      // attach additional listeners from options
+      if (options.onevent) entry.listeners.add(options.onevent)
+      if (options.oneose) entry.listeners.add(options.oneose)
+      if (options.onclose) entry.listeners.add(options.onclose)
+      this.subscriptionRegistry.set(key, entry)
+      return {
+        unsubscribe: () => {
+          entry.refCount -= 1
+          entry.listeners.delete(options.onevent)
+          entry.listeners.delete(options.oneose)
+          entry.listeners.delete(options.onclose)
+          if (entry.refCount <= 0) {
+            try { entry.sub.unsub() } catch(e) {}
+            this.subscriptionRegistry.delete(key)
+          }
+        }
+      }
     }
 
-    const relayUrls = readRelays.map(relay => relay.url)
-    console.log(`📥 Subscribing to events from ${relayUrls.length} relays`)
+    console.log(`📥 Subscribing to events from ${selected.length} relays`) 
+    const sub = this.pool.subscribeMany(selected, filters, { ...options, maxWait: options.maxWait || 10000 })
 
-    // Use pool.subscribeMany for reliable subscription
-    return this.pool.subscribeMany(relayUrls, filters, {
-      ...options,
-      maxWait: options.maxWait || 10000 // 10 second timeout
-    })
+    // Wrap and forward events to registered listeners
+    const listeners = new Set()
+    if (options.onevent) listeners.add(options.onevent)
+    if (options.oneose) listeners.add(options.oneose)
+    if (options.onclose) listeners.add(options.onclose)
+
+    // pool.subscribeMany typically returns an object with unsub or close and sets callbacks on it
+    // We attach a small adapter if sub provides on('event') style
+    if (sub && typeof sub.on === 'function') {
+      sub.on('event', (event) => listeners.forEach(fn => { try { fn(event) } catch(e){ console.error('subscription listener', e) } }))
+      sub.on('eose', () => listeners.forEach(fn => { try { if (typeof fn === 'function') fn({ type: 'eose' }) } catch(e){}}))
+      sub.on('close', (r) => listeners.forEach(fn => { try { if (typeof fn === 'function') fn({ type: 'close', reasons: r }) } catch(e){}}))
+    }
+
+    this.subscriptionRegistry.set(key, { sub, listeners, refCount: 1 })
+
+    return {
+      unsubscribe: () => {
+        const entry = this.subscriptionRegistry.get(key)
+        if (!entry) return
+        entry.refCount -= 1
+        if (entry.refCount <= 0) {
+          try { entry.sub.unsub() } catch(e) {}
+          this.subscriptionRegistry.delete(key)
+        }
+      }
+    }
+  }
+
+  // Normalize filters + relay list into a stable key string
+  _normalizeSubscriptionKey(filters, relays) {
+    try {
+      const sortedRelays = (relays || []).slice().sort().join(',')
+      const norm = JSON.stringify(filters, Object.keys(filters).sort())
+      return `${sortedRelays}|${norm}`
+    } catch (e) {
+      return `${Date.now()}`
+    }
   }
 
   // Get a single event
@@ -333,17 +531,43 @@ class NostrRelayManager {
     if (!this.isInitialized) {
       throw new Error('Relay manager not initialized')
     }
-
-    const readRelays = this.getReadRelays()
-    if (readRelays.length === 0) {
-      throw new Error('No read-enabled relays available')
-    }
-
-    const relayUrls = readRelays.map(relay => relay.url)
-    
+    // caching for profile lookups (kind:0 + single author)
     try {
-      const event = await this.pool.get(relayUrls, filters)
-      return event
+      if (filters && filters.kinds && filters.kinds.includes(0) && filters.authors && filters.authors.length === 1) {
+        const pub = filters.authors[0]
+        const cached = this.profileCache.get(pub)
+        if (cached && (Date.now() - cached.ts) < this.PROFILE_CACHE_TTL) return cached.profile
+      }
+
+      // select prioritized relays
+      const selected = this.selectRelaysForRead(options.limit || 4)
+      if (!selected || selected.length === 0) throw new Error('No read-enabled relays available')
+
+      // try prioritized read with timeout
+      const READ_TIMEOUT = (options.readTimeoutMs || 3000)
+      let ev = null
+      try {
+          // record requests against selected relays for throttling
+          selected.forEach(u => this.recordRelayRequest(u))
+          ev = await this.withTimeout(this.pool.get(selected, filters), READ_TIMEOUT)
+      } catch (e) {
+        // fallback to full list
+        try {
+          const all = this.getReadRelays().map(r=>r.url)
+            // record requests for fallback relays as well
+            all.forEach(u => this.recordRelayRequest(u))
+            ev = await this.pool.get(all, filters)
+        } catch (e2) {
+          throw e2
+        }
+      }
+
+      // if profile event, cache
+      if (ev && ev.kind === 0 && ev.pubkey) {
+        try { this.profileCache.set(ev.pubkey, { profile: ev, ts: Date.now() }) } catch (e) {}
+      }
+
+      return ev
     } catch (error) {
       console.error('❌ Failed to get event:', error)
       throw error
@@ -366,47 +590,66 @@ class NostrRelayManager {
   // Perform health check on all relays
   async performHealthCheck() {
     console.log('💓 Performing relay health check...')
-    
     const relayStatuses = this.getRelayStatuses()
     const healthPromises = relayStatuses.map(async (relayStatus) => {
+      const url = relayStatus.url
       try {
-        const connection = this.relayConnections.get(relayStatus.url)
+        const connection = this.relayConnections.get(url)
         if (!connection) {
           // Connection not in our map, try to reconnect
-          await this.reconnectRelay(relayStatus.url)
+          await this.reconnectRelay(url)
           return
+  // record publish requests for throttling
+  targets.forEach(u => this.recordRelayRequest(u))
         }
 
-        // Check if relay is still responsive by doing a simple query
+        // Check responsiveness via pool.get on this relay with a short timeout
         const testFilters = { kinds: [0], limit: 1 }
-        const timeout = new Promise((_, reject) => 
-          setTimeout(() => reject(new Error('Health check timeout')), 5000)
-        )
+        const start = Date.now()
+        await this.withTimeout(this.pool.get([url], testFilters), 4000)
 
-        await Promise.race([
-          this.pool.get([relayStatus.url], testFilters),
-          timeout
-        ])
+        // success: update meta
+        const meta = this.relayMeta.get(url) || { url }
+        meta.successes = (meta.successes || 0) + 1
+        meta.rtt = Date.now() - start
+        meta.lastFailure = meta.lastFailure || 0
+        meta.attempts = 0
+        this.relayMeta.set(url, meta)
 
-        // If we get here, relay is healthy
         if (relayStatus.status !== 'connected') {
-          this.setRelayStatus(relayStatus.url, 'connected', relayStatus.config)
-          this.emitEvent('relayHealthy', { url: relayStatus.url })
+          this.setRelayStatus(url, 'connected', relayStatus.config)
+          this.emitEvent('relayHealthy', { url })
         }
 
       } catch (error) {
-        console.warn(`💔 Health check failed for ${relayStatus.url}:`, error.message)
-        this.setRelayStatus(relayStatus.url, 'unhealthy', relayStatus.config, error.message)
-        this.emitEvent('relayUnhealthy', { url: relayStatus.url, error: error.message })
-        
-        // Try to reconnect unhealthy relays
-        setTimeout(() => {
-          this.reconnectRelay(relayStatus.url)
-        }, this.retryDelay)
+        console.warn(`💔 Health check failed for ${url}:`, error?.message || error)
+        const meta = this.relayMeta.get(url) || { url }
+        meta.failures = (meta.failures || 0) + 1
+        meta.lastFailure = Date.now()
+        meta.attempts = (meta.attempts || 0) + 1
+        this.relayMeta.set(url, meta)
+
+        this.setRelayStatus(url, 'unhealthy', relayStatus.config, error?.message || String(error))
+        this.emitEvent('relayUnhealthy', { url, error: error?.message || String(error) })
+
+        // exponential backoff before reconnecting
+        const backoff = Math.min(60_000, this.retryDelay * Math.pow(2, meta.attempts || 0))
+        setTimeout(() => this.reconnectRelay(url), backoff)
       }
     })
 
     await Promise.allSettled(healthPromises)
+
+    // recompute scores for prioritization
+    Array.from(this.relayMeta.values()).forEach(m => {
+      const successRate = (m.successes || 0) + (m.failures || 0) > 0 ? (m.successes || 0) / ((m.successes || 0) + (m.failures || 0)) : 0
+      const rttFactor = m.rtt === Infinity ? 0 : 1 / (1 + (m.rtt || 200) / 200)
+      m.score = successRate * 0.75 + rttFactor * 0.25
+      this.relayMeta.set(m.url, m)
+    })
+
+    // try flushing publish queue when health check runs
+    this.flushPublishQueue().catch(()=>{})
   }
 
   // Stop health check monitoring


### PR DESCRIPTION
Merge user NIP‑65 relays with defaults and persist choices. Track per‑relay health, RTT and failures to compute a score used for prioritizing reads and writes. Reads query top‑N healthy relays with a short timeout and fall back to the full pool. Publishes prefer healthy relays; failed publishes are enqueued in localStorage and retried with exponential backoff. Add a TTL cache for profiles, lightweight event cache hooks, background health checks that update scores and trigger queue flushes, and per‑relay telemetry/events for UI monitoring.

Approach
Import and merge NIP‑65 (kind 10002) relays on login/init and persist to localStorage. Centralize connections in a single pool and maintain relayMeta (success/fail, rtt, score). Select top scored read relays for fast reads (short timeout), fallback to all relays on timeout. Publish to preferred healthy write relays; on failure enqueue to zap_pending_publishes and retry with exponential backoff. Cache kind‑0 profiles in memory with TTL; provide simple event-cache hooks for future use. Run periodic background health checks to refresh scores, emit telemetry events, and flush the publish queue. Files changed: nostrRelayManager.js, useNostrAuth.js.