### PR TITLE
🚀 Implement Followers Tab in Audience Page with NIP-02 Discovery

### DIFF
--- a/src/pages/Audience.vue
+++ b/src/pages/Audience.vue
@@ -76,7 +76,8 @@ const {
   isFollowing,
   getMutualFollows,
   getFollowersCount,
-  getFollowingCount
+  getFollowingCount,
+  fetchProfile
 } = useAudience()
 
 // UI State
@@ -97,6 +98,7 @@ const tabs = [
   {
     id: 'overview', label: 'Overview', icon: IconTarget, count: null },
   { id: 'following', label: 'Following', icon: IconUserCheck, count: computed(() => getFollowingCount()) },
+  { id: 'followers', label: 'Followers', icon: IconUsers, count: computed(() => getFollowersCount()) },
   { id: 'lists', label: 'Follow Packs', icon: IconList, count: computed(() => myLists.value.length) },
   { id: 'suggestions', label: 'Suggestions', icon: IconUserPlus, count: computed(() => suggestedUsers.value.length) }
 ]
@@ -456,6 +458,7 @@ onMounted(() => {
   if (isAuthenticated.value) {
     // Start with overview for first-time users
     refreshFollowing()
+    refreshFollowers()
     
     // Generate suggestions after following list is loaded
     setTimeout(() => {
@@ -468,6 +471,7 @@ onMounted(() => {
 watch(isAuthenticated, (authenticated) => {
   if (authenticated) {
     refreshFollowing()
+    refreshFollowers()
     
     // Generate suggestions after following list is loaded
     setTimeout(() => {


### PR DESCRIPTION
## The problem

ZapTracker only showed Following (people you follow) but was missing Followers (people who follow you). This made it incomplete for managing your Nostr network since you couldn't see your audience.

## Closed: #60

## The solution

Added a new Followers tab that uses NIP-02 contact list discovery. It queries relays for kind:3 events that include the user's pubkey to find who's following them.

## What changed

- Added "Followers" tab between Following and Follow Packs
- Tab shows follower count like the other tabs
- Followers load automatically when you log in or refresh
- Same search, filtering, and profile interaction features as Following tab
- Uses the existing followers discovery logic that was already in the codebase

## Demo:

https://www.loom.com/share/2d7cdca5c7e94e6387d00e6388d15b5a

<img width="1920" height="968" alt="image" src="https://github.com/user-attachments/assets/2f08bb9b-fb1b-49fe-8871-fb246d7461e0" />

## Notes

The followers discovery was already implemented in the backend - this just connects it to the UI properly. No breaking changes to existing functionality.