### PR TITLE
Display full engagement metrics by separating reposts and quotes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3408,23 +3408,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/barcode-detector": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/barcode-detector/-/barcode-detector-0.7.0.tgz",
-      "integrity": "sha512-SJh+LV6e+W5e6QJe70ralFfqcYwvaOUGWyr+GepuQ5swPH4jF2asyTxOIUZNSU9Z5isD3KWI5hlqQ+b/QaFFOg==",
-      "deprecated": "The ownership of barcode-detector has been transferred to a new user. Please update to version 2.0.0 or higher for continued support and maintenance. View the new API and source code at https://github.com/Sec-ant/barcode-detector ",
-      "license": "MIT",
-      "dependencies": {
-        "@zxing/library": "^0.18.4",
-        "jsqr": "^1.3.1"
-      }
-    },
-    "node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
-      "license": "MIT"
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3697,17 +3680,6 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
-    },
-    "node_modules/core-js": {
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.43.0.tgz",
-      "integrity": "sha512-N6wEbTTZSYOY2rYAn85CuvWWkCK6QweMn7/4Nr3w+gDBeBhk/x4EJeY6FPo4QzDoJZxVTv8U7CMvgWk6pOHHqA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
     },
     "node_modules/core-js-compat": {
       "version": "3.43.0",

--- a/src/components/analytics/EngagementAnalytics.vue
+++ b/src/components/analytics/EngagementAnalytics.vue
@@ -8,7 +8,8 @@ import {
   IconFileText,
   IconEdit,
   IconTrendingUp,
-  IconChevronRight
+  IconChevronRight,
+  IconMessageForward
 } from '@iconify-prerendered/vue-tabler'
 import { useEngagementMetrics } from '../../composables/analytics/useEngagementMetrics.js'
 import { filterZapsByTimeRange } from '../../utils/core/timeFilter.js'
@@ -95,6 +96,7 @@ const buildContentPerformance = (typeFilter) => {
         zapAmount: 0,
         likes: engagement.likes,
         reposts: engagement.reposts,
+        quotes: engagement.quotes,
         bookmarks: engagement.bookmarks
       })
 
@@ -142,7 +144,7 @@ const buildContentPerformance = (typeFilter) => {
     .filter(content => content.type === typeFilter)
     .map(content => ({
       ...content,
-      totalScore: (content.zaps * 10) + (content.reposts * 3) + (content.likes * 1) + (content.bookmarks * 2)
+      totalScore: (content.zaps * 10) + (content.reposts * 3) + (content.quotes * 3) + (content.likes * 1) + (content.bookmarks * 2)
     }))
     .filter(content => content.totalScore > 0)
     .sort((a, b) => b.totalScore - a.totalScore)
@@ -268,6 +270,10 @@ const hasContent = computed(() => {
                       <IconRepeat class="w-3 h-3" />
                       <span>{{ formatNumber(note.reposts) }}</span>
                     </span>
+                    <span v-if="note.quotes > 0" class="flex items-center space-x-0.5 text-purple-600">
+                      <IconMessageForward class="w-3 h-3" />
+                      <span>{{ formatNumber(note.quotes) }}</span>
+                    </span>
                     <span v-if="note.bookmarks > 0" class="flex items-center space-x-0.5 text-blue-600">
                       <IconBookmark class="w-3 h-3" />
                       <span>{{ formatNumber(note.bookmarks) }}</span>
@@ -353,6 +359,10 @@ const hasContent = computed(() => {
                     <span v-if="article.reposts > 0" class="flex items-center space-x-0.5 text-green-600">
                       <IconRepeat class="w-3 h-3" />
                       <span>{{ formatNumber(article.reposts) }}</span>
+                    </span>
+                    <span v-if="article.quotes > 0" class="flex items-center space-x-0.5 text-purple-600">
+                      <IconMessageForward class="w-3 h-3" />
+                      <span>{{ formatNumber(article.quotes) }}</span>
                     </span>
                     <span v-if="article.bookmarks > 0" class="flex items-center space-x-0.5 text-blue-600">
                       <IconBookmark class="w-3 h-3" />

--- a/src/components/analytics/EngagementMetrics.vue
+++ b/src/components/analytics/EngagementMetrics.vue
@@ -6,7 +6,8 @@ import {
   IconRepeat,
   IconBolt,
   IconBookmarkFilled,
-  IconBookmark
+  IconBookmark,
+  IconMessageForward
 } from '@iconify-prerendered/vue-tabler'
 
 const props = defineProps({
@@ -16,6 +17,7 @@ const props = defineProps({
     default: () => ({
       likes: 0,
       reposts: 0,
+      quotes: 0,
       bookmarks: 0,
       totalEngagement: 0
     })
@@ -61,6 +63,7 @@ const hasEngagement = computed(() =>
 const hasAnyEngagement = computed(() => 
   (props.engagementCounts?.likes || 0) > 0 || 
   (props.engagementCounts?.reposts || 0) > 0 || 
+  (props.engagementCounts?.quotes || 0) > 0 || 
   (props.engagementCounts?.bookmarks || 0) > 0 || 
   props.zapCount > 0
 )
@@ -68,6 +71,7 @@ const hasAnyEngagement = computed(() =>
 const safeEngagementCounts = computed(() => ({
   likes: props.engagementCounts?.likes || 0,
   reposts: props.engagementCounts?.reposts || 0,
+  quotes: props.engagementCounts?.quotes || 0,
   bookmarks: props.engagementCounts?.bookmarks || 0,
   totalEngagement: props.engagementCounts?.totalEngagement || 0
 }))
@@ -98,6 +102,12 @@ const formatNumber = (num) => {
       <div v-if="showTooltips" class="custom-tooltip">{{ safeEngagementCounts.reposts }} {{ safeEngagementCounts.reposts <= 1 ? 'repost' : 'reposts' }}</div>
     </span>
     
+    <span :class="['flex items-center gap-1 px-2 py-0.5 rounded-md hover:bg-gray-50 transition-colors', showTooltips ? 'tooltip-container' : '']">
+      <IconMessageForward :class="[iconSizeClass, safeEngagementCounts.quotes > 0 ? 'text-purple-500' : 'text-gray-400']" />
+      <span :class="[textSize, 'font-medium']">{{ formatNumber(safeEngagementCounts.quotes) }}</span>
+      <div v-if="showTooltips" class="custom-tooltip">{{ safeEngagementCounts.quotes }} {{ safeEngagementCounts.quotes <= 1 ? 'quote' : 'quotes' }}</div>
+    </span>
+
     <span :class="['flex items-center gap-1 px-2 py-0.5 rounded-md hover:bg-orange-50 transition-colors', showTooltips ? 'tooltip-container' : '']">
       <IconBolt :class="[iconSizeClass, zapCount > 0 ? 'text-orange-500' : 'text-gray-400']" />
       <span :class="[textSize, 'font-medium', zapCount > 0 ? 'text-orange-600' : 'text-gray-500']">{{ formatNumber(zapCount) }}</span>

--- a/src/components/content/ContentEngagementChart.vue
+++ b/src/components/content/ContentEngagementChart.vue
@@ -46,13 +46,14 @@ const chartData = computed(() => {
       const eng = props.getEngagementCounts(item.nostrEventId) || {}
       const likes = eng.likes || 0
       const reposts = eng.reposts || 0
+      const quotes = eng.quotes || 0
       const bookmarks = eng.bookmarks || 0
       const zaps = item.zapCount || 0
       const name = item.title || 'Untitled'
       return {
         title: name.length > 20 ? name.substring(0, 20) + '...' : name,
-        likes, reposts, bookmarks, zaps,
-        total: likes + reposts + bookmarks + zaps
+        likes, reposts, quotes, bookmarks, zaps,
+        total: likes + reposts + quotes + bookmarks + zaps
       }
     })
     .sort((a, b) => b.total - a.total)
@@ -76,7 +77,7 @@ const chartOption = computed(() => {
       ...CHART_TOOLTIP_STYLE
     },
     legend: {
-      data: ['Likes', 'Reposts', 'Bookmarks', 'Zaps'],
+      data: ['Likes', 'Reposts', 'Quotes', 'Bookmarks', 'Zaps'],
       textStyle: { color: CHART_COLORS.titleText, fontSize: 10 },
       top: '12%'
     },
@@ -113,6 +114,13 @@ const chartOption = computed(() => {
         stack: 'engagement',
         data: items.map(p => p.reposts),
         itemStyle: { color: CHART_COLORS.green }
+      },
+      {
+        name: 'Quotes',
+        type: 'bar',
+        stack: 'engagement',
+        data: items.map(p => p.quotes),
+        itemStyle: { color: CHART_COLORS.purple || '#a855f7' }
       },
       {
         name: 'Bookmarks',

--- a/src/components/content/ContentList.vue
+++ b/src/components/content/ContentList.vue
@@ -21,7 +21,8 @@ import {
 import { 
   IconHeart,
   IconRepeat,
-  IconBookmark
+  IconBookmark,
+  IconMessageForward
 } from '@iconify-prerendered/vue-tabler'
 import EngagementMetrics from '../analytics/EngagementMetrics.vue'
 import { useEngagementMetrics } from '../../composables/analytics/useEngagementMetrics.js'
@@ -259,6 +260,18 @@ const getTotalRevenue = (item) => {
                 </div>
               </button>
               
+              <!-- Quotes -->
+              <button class="flex items-center space-x-2 text-gray-500 hover:text-purple-500 transition-colors group relative tooltip-container">
+                <IconMessageForward :class="[
+                  'w-4 h-4 transition-colors',
+                  getEngagementCounts(item.nostrEventId).quotes > 0 ? 'text-purple-500' : 'text-gray-400 group-hover:text-purple-500'
+                ]" />
+                <span class="text-sm font-medium">{{ getEngagementCounts(item.nostrEventId).quotes || 0 }}</span>
+                <div class="tooltip">
+                  {{ getEngagementCounts(item.nostrEventId).quotes || 0 }} {{ (getEngagementCounts(item.nostrEventId).quotes || 0) === 1 ? 'quote' : 'quotes' }} on Nostr
+                </div>
+              </button>
+
               <!-- Zaps -->
               <button class="flex items-center space-x-2 text-gray-500 hover:text-orange-500 transition-colors group relative tooltip-container">
                 <IconBolt :class="[
@@ -391,6 +404,18 @@ const getTotalRevenue = (item) => {
                 </div>
               </button>
               
+              <!-- Quotes -->
+              <button class="flex items-center space-x-2 text-gray-500 hover:text-purple-500 transition-colors group relative tooltip-container">
+                <IconMessageForward :class="[
+                  'w-5 h-5 transition-colors',
+                  getEngagementCounts(item.nostrEventId).quotes > 0 ? 'text-purple-500' : 'text-gray-400 group-hover:text-purple-500'
+                ]" />
+                <span class="text-sm font-medium">{{ getEngagementCounts(item.nostrEventId).quotes || 0 }}</span>
+                <div class="tooltip">
+                  {{ getEngagementCounts(item.nostrEventId).quotes || 0 }} {{ (getEngagementCounts(item.nostrEventId).quotes || 0) === 1 ? 'quote' : 'quotes' }} on Nostr
+                </div>
+              </button>
+
               <!-- Zaps -->
               <button class="flex items-center space-x-2 text-gray-500 hover:text-orange-500 transition-colors group relative tooltip-container">
                 <IconBolt :class="[
@@ -471,6 +496,10 @@ const getTotalRevenue = (item) => {
 
 .group:hover .group-hover\:text-orange-500 {
   color: #f97316;
+}
+
+.group:hover .group-hover\:text-purple-500 {
+  color: #a855f7;
 }
 
 .group:hover .group-hover\:text-blue-500 {

--- a/src/composables/analytics/useEngagementMetrics.js
+++ b/src/composables/analytics/useEngagementMetrics.js
@@ -12,6 +12,26 @@ const batchTimer = ref(null)
 const BATCH_DELAY = 1000
 const MAX_BATCH_SIZE = 50
 
+const createEmptyMetrics = () => ({
+  likes: [],
+  reposts: [],
+  quotes: [],
+  bookmarks: [],
+  zaps: [],
+  lastFetched: null,
+  isLoading: false
+})
+
+const normalizeMetrics = (metrics = {}) => ({
+  ...createEmptyMetrics(),
+  ...metrics,
+  likes: Array.isArray(metrics.likes) ? metrics.likes : [],
+  reposts: Array.isArray(metrics.reposts) ? metrics.reposts : [],
+  quotes: Array.isArray(metrics.quotes) ? metrics.quotes : [],
+  bookmarks: Array.isArray(metrics.bookmarks) ? metrics.bookmarks : [],
+  zaps: Array.isArray(metrics.zaps) ? metrics.zaps : []
+})
+
 // Load cached engagement metrics from localStorage immediately
 const ENGAGEMENT_STORAGE_KEY = 'engagement_metrics_cache'
 try {
@@ -19,7 +39,7 @@ try {
   if (cached) {
     const parsed = JSON.parse(cached)
     Object.entries(parsed).forEach(([eventId, metrics]) => {
-      engagementMetrics.set(eventId, metrics)
+      engagementMetrics.set(eventId, normalizeMetrics(metrics))
     })
   }
 } catch (e) {
@@ -46,15 +66,16 @@ export function useEngagementMetrics() {
 
   const initializeEngagementData = (eventId) => {
     if (!engagementMetrics.has(eventId)) {
-      engagementMetrics.set(eventId, {
-        likes: [],
-        reposts: [],
-        bookmarks: [],
-        zaps: [],
-        lastFetched: null,
-        isLoading: false
-      })
+      engagementMetrics.set(eventId, createEmptyMetrics())
+      return
     }
+
+    engagementMetrics.set(eventId, normalizeMetrics(engagementMetrics.get(eventId)))
+  }
+
+  const isQuoteRepost = (event) => {
+    const content = typeof event?.content === 'string' ? event.content.trim() : ''
+    return content.length > 0
   }
 
   const createEngagementData = (event, type, targetEventId = null) => {
@@ -86,11 +107,15 @@ export function useEngagementMetrics() {
         }
 
       case 'repost':
+      case 'quote': {
+        const content = event.content || ''
+        const isQuote = isQuoteRepost(event)
         return {
           ...baseData,
-          content: event.content || '',
-          isQuote: event.content.length > 0
+          content,
+          isQuote
         }
+      }
 
       case 'bookmark':
         return {
@@ -164,10 +189,12 @@ export function useEngagementMetrics() {
         targetArray = metrics.likes
         break
 
-      case 6:
-        engagementData = createEngagementData(event, 'repost', referencedEventId)
-        targetArray = metrics.reposts
+      case 6: {
+        const repostType = isQuoteRepost(event) ? 'quote' : 'repost'
+        engagementData = createEngagementData(event, repostType, referencedEventId)
+        targetArray = repostType === 'quote' ? metrics.quotes : metrics.reposts
         break
+      }
 
       case 10001:
       case 10002:
@@ -343,6 +370,7 @@ export function useEngagementMetrics() {
       return {
         likes: 0,
         reposts: 0,
+        quotes: 0,
         bookmarks: 0,
         totalEngagement: 0
       }
@@ -350,13 +378,15 @@ export function useEngagementMetrics() {
 
     const likes = metrics.likes.length
     const reposts = metrics.reposts.length
+    const quotes = metrics.quotes.length
     const bookmarks = metrics.bookmarks.length
 
     return {
       likes,
       reposts,
+      quotes,
       bookmarks,
-      totalEngagement: likes + reposts + bookmarks
+      totalEngagement: likes + reposts + quotes + bookmarks
     }
   }
 

--- a/src/pages/Notes.vue
+++ b/src/pages/Notes.vue
@@ -33,6 +33,7 @@ import {
   IconHeart,
   IconRepeat,
   IconBookmark,
+  IconMessageForward,
   IconX,
   IconCheck,
   IconCopy,
@@ -124,7 +125,7 @@ const showMediaPicker = ref(false)
 // Debounced note stats — avoids recomputing on every single zap/engagement event
 const noteStats = ref({
   total: 0, thisWeek: 0, totalZapRevenue: 0, totalLikes: 0,
-  totalReposts: 0, totalBookmarks: 0, totalZapCount: 0, totalEngagement: 0
+  totalReposts: 0, totalQuotes: 0, totalBookmarks: 0, totalZapCount: 0, totalEngagement: 0
 })
 
 let _noteStatsTimer = null
@@ -132,7 +133,7 @@ function recalcNoteStats() {
   clearTimeout(_noteStatsTimer)
   _noteStatsTimer = setTimeout(() => {
     const list = Array.isArray(notes.value) ? notes.value : []
-    let totalZapRevenue = 0, totalLikes = 0, totalReposts = 0, totalBookmarks = 0, totalZapCount = 0
+    let totalZapRevenue = 0, totalLikes = 0, totalReposts = 0, totalQuotes = 0, totalBookmarks = 0, totalZapCount = 0
 
     for (const note of list) {
       totalZapRevenue += getTotalZapAmount(note.id)
@@ -140,6 +141,7 @@ function recalcNoteStats() {
       const ec = getEngagementCounts(note.id) || {}
       totalLikes += ec.likes || 0
       totalReposts += ec.reposts || 0
+      totalQuotes += ec.quotes || 0
       totalBookmarks += ec.bookmarks || 0
     }
 
@@ -147,8 +149,8 @@ function recalcNoteStats() {
     noteStats.value = {
       total: list.length,
       thisWeek: list.filter(n => n.created_at * 1000 > weekAgo).length,
-      totalZapRevenue, totalLikes, totalReposts, totalBookmarks, totalZapCount,
-      totalEngagement: totalLikes + totalReposts + totalBookmarks + totalZapCount
+      totalZapRevenue, totalLikes, totalReposts, totalQuotes, totalBookmarks, totalZapCount,
+      totalEngagement: totalLikes + totalReposts + totalQuotes + totalBookmarks + totalZapCount
     }
   }, 2000)
 }
@@ -597,6 +599,10 @@ const handleMentionClick = ({ pubkey, profile }) => {
                 <span class="flex items-center gap-1">
                   <IconRepeat class="w-3 h-3 text-green-500" />
                   <span class="text-green-600 font-medium">{{ noteStats.totalReposts }}</span>
+                </span>
+                <span class="flex items-center gap-1">
+                  <IconMessageForward class="w-3 h-3 text-purple-500" />
+                  <span class="text-purple-600 font-medium">{{ noteStats.totalQuotes }}</span>
                 </span>
                 <span class="flex items-center gap-1">
                   <IconBolt class="w-3 h-3 text-orange-500" />


### PR DESCRIPTION
## What the issue asked for

This issue asked for full engagement metrics to be displayed for content, specifically breaking out:

- likes
- reposts
- quotes
- bookmarks

instead of treating repost activity as a single bucket.

## What this patch does

This patch separates `kind:6` engagement into distinct **reposts** and **quotes**, then carries that distinction through the main engagement display and analytics surfaces.

### Core logic change
`src/composables/analytics/useEngagementMetrics.js`
- adds first-class `quotes` storage and return values
- normalizes cached engagement objects loaded from localStorage so older cache entries still work
- updates `totalEngagement` to include quotes
- splits `kind:6` events into:
  - `reposts`
  - `quotes`

### UI / analytics updates
Patched:
- `src/composables/analytics/useEngagementMetrics.js`
- `src/components/analytics/EngagementMetrics.vue`
- `src/pages/Notes.vue`
- `src/components/content/ContentEngagementChart.vue`
- `src/components/analytics/EngagementAnalytics.vue`
- `src/components/content/ContentList.vue`

### Files checked and intentionally skipped
Checked but not patched:
- `src/pages/Content.vue`
  - already consumes `totalEngagement` or passes `getEngagementCounts` down to child components
- `src/components/content/ContentTagPerformance.vue`
  - already uses `engagement.totalEngagement`, so quotes flow through transitively
- `src/components/content/ContentPerformance.vue`
  - zap-only analytics, no engagement metric aggregation
- `src/components/content/ContentTopSupporters.vue`
  - zap-only aggregation, no engagement metric handling

## Heuristic used to split reposts from quotes

This patch uses the following `kind:6` split:

- **empty content** → repost
- **non-empty content** → quote

This matches the expected Nostr behavior:
- reposts per NIP-18 should have empty content and reference the target event in tags
- quote reposts typically include a `note` / `nevent` reference in the content field

### Edge cases
- whitespace-only content is handled via `trim()`, so whitespace-only content is treated as empty and counted as a repost
- some clients may put structured or JSON-like content into `kind:6` content; in those cases this heuristic could produce false positives and classify the event as a quote

## Notes on scoring

In `EngagementAnalytics.vue`, quotes are weighted the same as reposts (`3`) for now.

That avoids making a product decision unilaterally in this patch. Quotes could reasonably be weighted higher in future if the maintainer wants to treat them as stronger engagement.

## No existing test suite

I did not find an existing unit/spec test suite covering `useEngagementMetrics` or `kind:6` handling in this repository.

## Known inefficiency

`src/components/content/ContentList.vue` now renders quotes correctly, but it still calls `getEngagementCounts(item.nostrEventId)` multiple times per render for the same item.

That existed as a general pattern already and is worth a future refactor to cache counts per item within the render path.

## Verification

Verified with:

```bash
npm install
npm run build
```

The production build completed successfully.

Build warnings were present, but they appear pre-existing and unrelated to this patch:
- deprecated npm dependencies
- outdated Browserslist database
- ECharts dynamic/static import chunking warnings
- large chunk size warnings

No new build-breaking errors were introduced by this change.
