### PR TITLE
Add Nostr quote engagement metrics

### DIFF
--- a/src/components/analytics/EngagementAnalytics.vue
+++ b/src/components/analytics/EngagementAnalytics.vue
@@ -5,6 +5,7 @@ import {
   IconHeart,
   IconRepeat,
   IconBookmark,
+  IconQuote,
   IconFileText,
   IconEdit,
   IconTrendingUp,
@@ -95,6 +96,7 @@ const buildContentPerformance = (typeFilter) => {
         zapAmount: 0,
         likes: engagement.likes,
         reposts: engagement.reposts,
+        quotes: engagement.quotes || 0,
         bookmarks: engagement.bookmarks
       })
 
@@ -142,7 +144,7 @@ const buildContentPerformance = (typeFilter) => {
     .filter(content => content.type === typeFilter)
     .map(content => ({
       ...content,
-      totalScore: (content.zaps * 10) + (content.reposts * 3) + (content.likes * 1) + (content.bookmarks * 2)
+      totalScore: (content.zaps * 10) + (content.reposts * 3) + (content.quotes * 2) + (content.likes * 1) + (content.bookmarks * 2)
     }))
     .filter(content => content.totalScore > 0)
     .sort((a, b) => b.totalScore - a.totalScore)
@@ -268,6 +270,10 @@ const hasContent = computed(() => {
                       <IconRepeat class="w-3 h-3" />
                       <span>{{ formatNumber(note.reposts) }}</span>
                     </span>
+                    <span v-if="note.quotes > 0" class="flex items-center space-x-0.5 text-purple-600">
+                      <IconQuote class="w-3 h-3" />
+                      <span>{{ formatNumber(note.quotes) }}</span>
+                    </span>
                     <span v-if="note.bookmarks > 0" class="flex items-center space-x-0.5 text-blue-600">
                       <IconBookmark class="w-3 h-3" />
                       <span>{{ formatNumber(note.bookmarks) }}</span>
@@ -353,6 +359,10 @@ const hasContent = computed(() => {
                     <span v-if="article.reposts > 0" class="flex items-center space-x-0.5 text-green-600">
                       <IconRepeat class="w-3 h-3" />
                       <span>{{ formatNumber(article.reposts) }}</span>
+                    </span>
+                    <span v-if="article.quotes > 0" class="flex items-center space-x-0.5 text-purple-600">
+                      <IconQuote class="w-3 h-3" />
+                      <span>{{ formatNumber(article.quotes) }}</span>
                     </span>
                     <span v-if="article.bookmarks > 0" class="flex items-center space-x-0.5 text-blue-600">
                       <IconBookmark class="w-3 h-3" />

--- a/src/components/analytics/EngagementMetrics.vue
+++ b/src/components/analytics/EngagementMetrics.vue
@@ -4,6 +4,7 @@ import {
   IconHeartFilled,
   IconHeart,
   IconRepeat,
+  IconQuote,
   IconBolt,
   IconBookmarkFilled,
   IconBookmark
@@ -16,6 +17,7 @@ const props = defineProps({
     default: () => ({
       likes: 0,
       reposts: 0,
+      quotes: 0,
       bookmarks: 0,
       totalEngagement: 0
     })
@@ -61,6 +63,7 @@ const hasEngagement = computed(() =>
 const hasAnyEngagement = computed(() => 
   (props.engagementCounts?.likes || 0) > 0 || 
   (props.engagementCounts?.reposts || 0) > 0 || 
+  (props.engagementCounts?.quotes || 0) > 0 || 
   (props.engagementCounts?.bookmarks || 0) > 0 || 
   props.zapCount > 0
 )
@@ -68,6 +71,7 @@ const hasAnyEngagement = computed(() =>
 const safeEngagementCounts = computed(() => ({
   likes: props.engagementCounts?.likes || 0,
   reposts: props.engagementCounts?.reposts || 0,
+  quotes: props.engagementCounts?.quotes || 0,
   bookmarks: props.engagementCounts?.bookmarks || 0,
   totalEngagement: props.engagementCounts?.totalEngagement || 0
 }))
@@ -96,6 +100,12 @@ const formatNumber = (num) => {
       <IconRepeat :class="[iconSizeClass, safeEngagementCounts.reposts > 0 ? 'text-green-500' : 'text-gray-400']" />
       <span :class="[textSize, 'font-medium']">{{ formatNumber(safeEngagementCounts.reposts) }}</span>
       <div v-if="showTooltips" class="custom-tooltip">{{ safeEngagementCounts.reposts }} {{ safeEngagementCounts.reposts <= 1 ? 'repost' : 'reposts' }}</div>
+    </span>
+
+    <span :class="['flex items-center gap-1 px-2 py-0.5 rounded-md hover:bg-gray-50 transition-colors', showTooltips ? 'tooltip-container' : '']">
+      <IconQuote :class="[iconSizeClass, safeEngagementCounts.quotes > 0 ? 'text-purple-500' : 'text-gray-400']" />
+      <span :class="[textSize, 'font-medium']">{{ formatNumber(safeEngagementCounts.quotes) }}</span>
+      <div v-if="showTooltips" class="custom-tooltip">{{ safeEngagementCounts.quotes }} {{ safeEngagementCounts.quotes <= 1 ? 'quote' : 'quotes' }}</div>
     </span>
     
     <span :class="['flex items-center gap-1 px-2 py-0.5 rounded-md hover:bg-orange-50 transition-colors', showTooltips ? 'tooltip-container' : '']">

--- a/src/components/content/ContentEngagementChart.vue
+++ b/src/components/content/ContentEngagementChart.vue
@@ -46,13 +46,14 @@ const chartData = computed(() => {
       const eng = props.getEngagementCounts(item.nostrEventId) || {}
       const likes = eng.likes || 0
       const reposts = eng.reposts || 0
+      const quotes = eng.quotes || 0
       const bookmarks = eng.bookmarks || 0
       const zaps = item.zapCount || 0
       const name = item.title || 'Untitled'
       return {
         title: name.length > 20 ? name.substring(0, 20) + '...' : name,
-        likes, reposts, bookmarks, zaps,
-        total: likes + reposts + bookmarks + zaps
+        likes, reposts, quotes, bookmarks, zaps,
+        total: likes + reposts + quotes + bookmarks + zaps
       }
     })
     .sort((a, b) => b.total - a.total)
@@ -76,7 +77,7 @@ const chartOption = computed(() => {
       ...CHART_TOOLTIP_STYLE
     },
     legend: {
-      data: ['Likes', 'Reposts', 'Bookmarks', 'Zaps'],
+      data: ['Likes', 'Reposts', 'Quotes', 'Bookmarks', 'Zaps'],
       textStyle: { color: CHART_COLORS.titleText, fontSize: 10 },
       top: '12%'
     },
@@ -113,6 +114,13 @@ const chartOption = computed(() => {
         stack: 'engagement',
         data: items.map(p => p.reposts),
         itemStyle: { color: CHART_COLORS.green }
+      },
+      {
+        name: 'Quotes',
+        type: 'bar',
+        stack: 'engagement',
+        data: items.map(p => p.quotes),
+        itemStyle: { color: '#a855f7' }
       },
       {
         name: 'Bookmarks',

--- a/src/components/content/ContentList.vue
+++ b/src/components/content/ContentList.vue
@@ -21,6 +21,7 @@ import {
 import { 
   IconHeart,
   IconRepeat,
+  IconQuote,
   IconBookmark
 } from '@iconify-prerendered/vue-tabler'
 import EngagementMetrics from '../analytics/EngagementMetrics.vue'
@@ -258,6 +259,18 @@ const getTotalRevenue = (item) => {
                   {{ getEngagementCounts(item.nostrEventId).reposts || 0 }} {{ (getEngagementCounts(item.nostrEventId).reposts || 0) === 1 ? 'repost' : 'reposts' }} on Nostr
                 </div>
               </button>
+
+              <!-- Quotes -->
+              <button class="flex items-center space-x-2 text-gray-500 hover:text-purple-500 transition-colors group relative tooltip-container">
+                <IconQuote :class="[
+                  'w-4 h-4 transition-colors',
+                  getEngagementCounts(item.nostrEventId).quotes > 0 ? 'text-purple-500' : 'text-gray-400 group-hover:text-purple-500'
+                ]" />
+                <span class="text-sm font-medium">{{ getEngagementCounts(item.nostrEventId).quotes || 0 }}</span>
+                <div class="tooltip">
+                  {{ getEngagementCounts(item.nostrEventId).quotes || 0 }} {{ (getEngagementCounts(item.nostrEventId).quotes || 0) === 1 ? 'quote' : 'quotes' }} on Nostr
+                </div>
+              </button>
               
               <!-- Zaps -->
               <button class="flex items-center space-x-2 text-gray-500 hover:text-orange-500 transition-colors group relative tooltip-container">
@@ -388,6 +401,18 @@ const getTotalRevenue = (item) => {
                 <span class="text-sm font-medium">{{ getEngagementCounts(item.nostrEventId).reposts || 0 }}</span>
                 <div class="tooltip">
                   {{ getEngagementCounts(item.nostrEventId).reposts || 0 }} {{ (getEngagementCounts(item.nostrEventId).reposts || 0) === 1 ? 'repost' : 'reposts' }} on Nostr
+                </div>
+              </button>
+
+              <!-- Quotes -->
+              <button class="flex items-center space-x-2 text-gray-500 hover:text-purple-500 transition-colors group relative tooltip-container">
+                <IconQuote :class="[
+                  'w-5 h-5 transition-colors',
+                  getEngagementCounts(item.nostrEventId).quotes > 0 ? 'text-purple-500' : 'text-gray-400 group-hover:text-purple-500'
+                ]" />
+                <span class="text-sm font-medium">{{ getEngagementCounts(item.nostrEventId).quotes || 0 }}</span>
+                <div class="tooltip">
+                  {{ getEngagementCounts(item.nostrEventId).quotes || 0 }} {{ (getEngagementCounts(item.nostrEventId).quotes || 0) === 1 ? 'quote' : 'quotes' }} on Nostr
                 </div>
               </button>
               

--- a/src/composables/analytics/useEngagementMetrics.js
+++ b/src/composables/analytics/useEngagementMetrics.js
@@ -49,6 +49,7 @@ export function useEngagementMetrics() {
       engagementMetrics.set(eventId, {
         likes: [],
         reposts: [],
+        quotes: [],
         bookmarks: [],
         zaps: [],
         lastFetched: null,
@@ -90,6 +91,12 @@ export function useEngagementMetrics() {
           ...baseData,
           content: event.content || '',
           isQuote: event.content.length > 0
+        }
+
+      case 'quote':
+        return {
+          ...baseData,
+          content: event.content || ''
         }
 
       case 'bookmark':
@@ -146,7 +153,7 @@ export function useEngagementMetrics() {
       }
     }
 
-    let referencedEventId = targetEventId || event.tags.find(tag => tag[0] === 'e')?.[1]
+    let referencedEventId = targetEventId || event.tags.find(tag => tag[0] === 'q')?.[1] || event.tags.find(tag => tag[0] === 'e')?.[1]
     
     if (!referencedEventId && !targetEventId) {
       return
@@ -167,6 +174,14 @@ export function useEngagementMetrics() {
       case 6:
         engagementData = createEngagementData(event, 'repost', referencedEventId)
         targetArray = metrics.reposts
+        break
+
+      case 1:
+        if (!event.tags.some(tag => tag[0] === 'q' && tag[1] === referencedEventId)) {
+          return
+        }
+        engagementData = createEngagementData(event, 'quote', referencedEventId)
+        targetArray = metrics.quotes
         break
 
       case 10001:
@@ -212,6 +227,11 @@ export function useEngagementMetrics() {
         {
           kinds: [6],
           "#e": uniqueEventIds,
+          limit: 200
+        },
+        {
+          kinds: [1],
+          "#q": uniqueEventIds,
           limit: 200
         },
         {
@@ -343,6 +363,7 @@ export function useEngagementMetrics() {
       return {
         likes: 0,
         reposts: 0,
+        quotes: 0,
         bookmarks: 0,
         totalEngagement: 0
       }
@@ -350,13 +371,15 @@ export function useEngagementMetrics() {
 
     const likes = metrics.likes.length
     const reposts = metrics.reposts.length
+    const quotes = metrics.quotes?.length || 0
     const bookmarks = metrics.bookmarks.length
 
     return {
       likes,
       reposts,
+      quotes,
       bookmarks,
-      totalEngagement: likes + reposts + bookmarks
+      totalEngagement: likes + reposts + quotes + bookmarks
     }
   }
 
@@ -422,6 +445,11 @@ export function useEngagementMetrics() {
         {
           kinds: [6],
           "#a": [aTagIdentifier],
+          limit: 100
+        },
+        {
+          kinds: [1],
+          "#q": [aTagIdentifier],
           limit: 100
         },
         {


### PR DESCRIPTION
This PR adds quote tracking to the existing Nostr engagement metrics flow so content analytics can display likes, reposts, quotes, and bookmarks together.

Changes:
- Fetches Nostr kind `1` quote events using `#q` tags for tracked content.
- Stores quote engagement alongside likes, reposts, bookmarks, and zaps.
- Includes quotes in `totalEngagement` and top-performing content scoring.
- Displays quote counts in engagement summary UI, content list rows, top-performing content, and the engagement chart.

Verification:
- Ran `npm run build` successfully.

Notes:
- Existing Vite warnings about Browserslist age, ECharts import chunking, and large chunks still appear. They are pre-existing build warnings and are not caused by this change.